### PR TITLE
Add redfish_tools gem development dependency

### DIFF
--- a/manageiq-providers-redfish.gemspec
+++ b/manageiq-providers-redfish.gemspec
@@ -16,5 +16,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "redfish_client", "~> 0.1"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
+  s.add_development_dependency "redfish_tools", "~> 0.1"
   s.add_development_dependency "simplecov"
 end


### PR DESCRIPTION
Developing Redfish client without access to Redfish-capable system is
next to impossible and getting access to such system is no walk in the
park either.

Installing redfish_tools gem bypasses all those obstacles by providing
a development server that can serve Redfish service recordings.

@miq-bot add_reviewer @matejart 