### PR TITLE
Add power operations to physical server

### DIFF
--- a/app/models/manageiq/providers/redfish/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager.rb
@@ -5,6 +5,7 @@ module ManageIQ::Providers::Redfish
 
     include Vmdb::Logging
     include ManagerMixin
+    include_concern "Operations"
 
     has_many :physical_server_details,
              :class_name => "AssetDetail",

--- a/app/models/manageiq/providers/redfish/physical_infra_manager/operations.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager/operations.rb
@@ -1,0 +1,7 @@
+module ManageIQ::Providers::Redfish
+  module PhysicalInfraManager::Operations
+    extend ActiveSupport::Concern
+
+    include_concern "Power"
+  end
+end

--- a/app/models/manageiq/providers/redfish/physical_infra_manager/operations/power.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager/operations/power.rb
@@ -1,0 +1,65 @@
+module ManageIQ::Providers::Redfish
+  module PhysicalInfraManager::Operations::Power
+    # Keep this in sync with app/models/physical_server/operations/power.rb in
+    # core and ResetType enum in Redfish Resource type. Name of the method
+    # comes from the core and the action name used in the reset call from the
+    # ResetType enum.
+    #
+    # NOTE: Not all reset operations are implemented on all servers, so any of
+    # the methods listed here can fail. We need to find a way to let those
+    # failures bubble up to the user interface somehow or risk having a
+    # completely useless tool.
+
+    def power_on(server, _options)
+      reset_server(server, "On")
+    end
+
+    def power_off(server, _options)
+      reset_server(server, "GracefulShutdown")
+    end
+
+    def power_off_now(server, _options)
+      reset_server(server, "ForceOff")
+    end
+
+    def restart(server, _options)
+      reset_server(server, "GracefulRestart")
+    end
+
+    def restart_now(server, _options)
+      reset_server(server, "ForceRestart")
+    end
+
+    def restart_to_sys_setup(_args, _options)
+      $redfish_log.error("Restarting to system setup is not supported.")
+    end
+
+    def restart_mgmt_controller(_server, _options)
+      # TODO(tadeboro): This operation is not well defined, since server can
+      # (and usually is) managed by more that one manager.
+      $redfish_log.error("Restarting management controller is not supported.")
+    end
+
+    private
+
+    def reset_server(server, reset_type)
+      $redfish_log.info("Requesting #{reset_type} for #{server.ems_ref}.")
+      with_provider_connection do |client|
+        system = client.find(server.ems_ref)
+        if system.nil?
+          $redfish_log.error("#{server.ems_ref} does not exist anymore.")
+          return
+        end
+
+        response = system.Actions["#ComputerSystem.Reset"].post(
+          :field => "target", :payload => { "ResetType" => reset_type }
+        )
+        if [200, 202, 204].include?(response.status)
+          $redfish_log.info("#{reset_type} for #{server.ems_ref} started.")
+        else
+          $redfish_log.error("#{reset_type} for #{server.ems_ref} failed.")
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -10,6 +10,9 @@ FactoryGirl.define do
     end
 
     trait :vcr do
+      security_protocol "ssl"
+      port 8889
+
       hostname do
         # Keep in sync with filter_sensitive_data in spec/spec_helper.rb!
         Rails.application.secrets.redfish.try(:[], "host") || "redfishhost"

--- a/spec/factories/physical_server.rb
+++ b/spec/factories/physical_server.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :redfish_physical_server,
+          :class  => ManageIQ::Providers::Redfish::PhysicalInfraManager::PhysicalServer,
+          :parent => :physical_server do
+    trait :vcr do
+      ems_ref "/redfish/v1/Systems/System.Embedded.1"
+    end
+  end
+end

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/operations/power_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/operations/power_spec.rb
@@ -1,0 +1,48 @@
+describe ManageIQ::Providers::Redfish::PhysicalInfraManager do
+  let(:server) { FactoryGirl.create(:redfish_physical_server, :vcr) }
+  subject(:ems) do
+    FactoryGirl.create(:ems_redfish_physical_infra, :vcr)
+  end
+
+  describe "#power_on", :vcr do
+    it "powers on the system" do
+      ems.power_on(server, nil)
+    end
+  end
+
+  describe "#power_off", :vcr do
+    it "powers off the system" do
+      ems.power_off(server, nil)
+    end
+  end
+
+  describe "#power_off_now", :vcr do
+    it "powers off the system immediately" do
+      ems.power_off_now(server, nil)
+    end
+  end
+
+  describe "#restart", :vcr do
+    it "restarts the system" do
+      ems.restart(server, nil)
+    end
+  end
+
+  describe "#restart_now", :vcr do
+    it "restarts the system immediately" do
+      ems.restart_now(server, nil)
+    end
+  end
+
+  describe "#restart_to_sys_setup", :vcr do
+    it "restarts to system setup" do
+      ems.restart_to_sys_setup(server, nil)
+    end
+  end
+
+  describe "#restart_mgmt_controller", :vcr do
+    it "restarts management controller" do
+      ems.restart_mgmt_controller(server, nil)
+    end
+  end
+end

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_off/powers_off_the_system.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_off/powers_off_the_system.yml
@@ -1,0 +1,191 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      Date:
+      - Mon, 04 Jun 2018 10:23:19 GMT
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.context": "/redfish/v1/$metadata#ServiceRoot.ServiceRoot",
+        "@odata.id": "/redfish/v1", "@odata.type": "#ServiceRoot.v1_1_0.ServiceRoot",
+        "AccountService": {"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},
+        "Chassis": {"@odata.id": "/redfish/v1/Chassis"}, "Description": "Root Service",
+        "EventService": {"@odata.id": "/redfish/v1/EventService"}, "Id": "RootService",
+        "JsonSchemas": {"@odata.id": "/redfish/v1/JSONSchemas"}, "Links": {"Sessions":
+        {"@odata.id": "/redfish/v1/Sessions"}}, "Managers": {"@odata.id": "/redfish/v1/Managers"},
+        "Name": "Root Service", "Oem": {"Dell": {"@odata.type": "/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot",
+        "IsBranded": 0, "ManagerMACAddress": "10:98:36:a9:05:b0", "ServiceTag": ""}},
+        "RedfishVersion": "1.0.2", "Registries": {"@odata.id": "/redfish/v1/Registries"},
+        "SessionService": {"@odata.id": "/redfish/v1/SessionService"}, "Systems":
+        {"@odata.id": "/redfish/v1/Systems"}, "Tasks": {"@odata.id": "/redfish/v1/TaskService"},
+        "UpdateService": {"@odata.id": "/redfish/v1/UpdateService"}}'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+- request:
+    method: post
+    uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
+    body:
+      encoding: UTF-8
+      string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      Date:
+      - Mon, 04 Jun 2018 10:23:19 GMT
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+      Location:
+      - "/redfish/v1/Sessions/a7d2f27a-c64d-491c-ace1-508923551fcd"
+      X-Auth-Token:
+      - 21161704-7ba8-421f-ae23-7f1464e261f3
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.context": "/redfish/v1/$metadata#Session.Session", "@odata.type":
+        "#Session.v1_0_0.Session", "Name": "User Session", "Description": "User Session",
+        "UserName": "REDFISH_USERID", "@odata.id": "/redfish/v1/Sessions/a7d2f27a-c64d-491c-ace1-508923551fcd",
+        "Id": "a7d2f27a-c64d-491c-ace1-508923551fcd"}'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 21161704-7ba8-421f-ae23-7f1464e261f3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      Date:
+      - Mon, 04 Jun 2018 10:23:19 GMT
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"SimpleStorage": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},
+        "Links": {"CooledBy@odata.count": 12, "PoweredBy@odata.count": 0, "Oem": {"Dell":
+        {"BootSources": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"},
+        "@odata.type": "#Dell.v1_0_0.BootSources"}}, "ManagedBy": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}],
+        "Chassis": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1"}], "Chassis@odata.count":
+        1, "PoweredBy": [], "CooledBy": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],
+        "ManagedBy@odata.count": 1}, "Processors": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"},
+        "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+        "Manufacturer": "Dell Inc.", "PowerState": "Off", "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        "Name": "System", "AssetTag": "", "HostName": "", "SerialNumber": "CN701636AB0013",
+        "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem", "TrustedModules":
+        [{"Status": {"State": "Disabled"}}], "IndicatorLED": "Off", "SKU": "", "MemorySummary":
+        {"TotalSystemMemoryGiB": 32.0, "Status": {"State": "Enabled", "Health": null,
+        "HealthRollup": null}, "MemoryMirroring": "System"}, "Model": "DSS9630M",
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1", "Id": "System.Embedded.1",
+        "Bios": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"}, "SecureBoot":
+        {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"}, "ProcessorSummary":
+        {"Status": {"State": "Enabled", "Health": null, "HealthRollup": null}, "Count":
+        2, "Model": ""}, "SystemType": "Physical", "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+        "PartNumber": "033RF3X04", "BiosVersion": "0.4.8", "EthernetInterfaces": {"@odata.id":
+        "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"}, "Description":
+        "Computer System which represents a machine (physical or virtual) and the
+        local resources such as memory, cpu and other devices that can be accessed
+        from that machine.", "Actions": {"#ComputerSystem.Reset": {"target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+        "ResetType@Redfish.AllowableValues": ["On", "ForceOff", "GracefulRestart",
+        "GracefulShutdown", "PushPowerButton", "Nmi"]}}, "Boot": {"UefiTargetBootSourceOverride":
+        "", "BootSourceOverrideTarget": "None", "BootSourceOverrideTarget@Redfish.AllowableValues":
+        ["None", "Pxe", "Floppy", "Cd", "Hdd", "BiosSetup", "Utilities", "UefiTarget",
+        "SDCard", "UefiHttp"], "BootSourceOverrideEnabled": "Once", "BootSourceOverrideMode":
+        "UEFI"}, "Status": {"State": "StandbyOffline", "Health": "OK", "HealthRollup":
+        "OK"}}'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+- request:
+    method: post
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset
+    body:
+      encoding: UTF-8
+      string: '{"ResetType":"GracefulShutdown"}'
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 21161704-7ba8-421f-ae23-7f1464e261f3
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      Date:
+      - Mon, 04 Jun 2018 10:23:19 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_off_now/powers_off_the_system_immediately.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_off_now/powers_off_the_system_immediately.yml
@@ -1,0 +1,191 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      Date:
+      - Mon, 04 Jun 2018 10:23:19 GMT
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.context": "/redfish/v1/$metadata#ServiceRoot.ServiceRoot",
+        "@odata.id": "/redfish/v1", "@odata.type": "#ServiceRoot.v1_1_0.ServiceRoot",
+        "AccountService": {"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},
+        "Chassis": {"@odata.id": "/redfish/v1/Chassis"}, "Description": "Root Service",
+        "EventService": {"@odata.id": "/redfish/v1/EventService"}, "Id": "RootService",
+        "JsonSchemas": {"@odata.id": "/redfish/v1/JSONSchemas"}, "Links": {"Sessions":
+        {"@odata.id": "/redfish/v1/Sessions"}}, "Managers": {"@odata.id": "/redfish/v1/Managers"},
+        "Name": "Root Service", "Oem": {"Dell": {"@odata.type": "/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot",
+        "IsBranded": 0, "ManagerMACAddress": "10:98:36:a9:05:b0", "ServiceTag": ""}},
+        "RedfishVersion": "1.0.2", "Registries": {"@odata.id": "/redfish/v1/Registries"},
+        "SessionService": {"@odata.id": "/redfish/v1/SessionService"}, "Systems":
+        {"@odata.id": "/redfish/v1/Systems"}, "Tasks": {"@odata.id": "/redfish/v1/TaskService"},
+        "UpdateService": {"@odata.id": "/redfish/v1/UpdateService"}}'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+- request:
+    method: post
+    uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
+    body:
+      encoding: UTF-8
+      string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      Date:
+      - Mon, 04 Jun 2018 10:23:19 GMT
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+      Location:
+      - "/redfish/v1/Sessions/a4a5ec46-452f-4ef8-b8f3-98d144da1821"
+      X-Auth-Token:
+      - b94407d9-d5dc-4ba3-8689-bc9f11a195ec
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.context": "/redfish/v1/$metadata#Session.Session", "@odata.type":
+        "#Session.v1_0_0.Session", "Name": "User Session", "Description": "User Session",
+        "UserName": "REDFISH_USERID", "@odata.id": "/redfish/v1/Sessions/a4a5ec46-452f-4ef8-b8f3-98d144da1821",
+        "Id": "a4a5ec46-452f-4ef8-b8f3-98d144da1821"}'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b94407d9-d5dc-4ba3-8689-bc9f11a195ec
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      Date:
+      - Mon, 04 Jun 2018 10:23:19 GMT
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"SimpleStorage": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},
+        "Links": {"CooledBy@odata.count": 12, "PoweredBy@odata.count": 0, "Oem": {"Dell":
+        {"BootSources": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"},
+        "@odata.type": "#Dell.v1_0_0.BootSources"}}, "ManagedBy": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}],
+        "Chassis": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1"}], "Chassis@odata.count":
+        1, "PoweredBy": [], "CooledBy": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],
+        "ManagedBy@odata.count": 1}, "Processors": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"},
+        "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+        "Manufacturer": "Dell Inc.", "PowerState": "Off", "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        "Name": "System", "AssetTag": "", "HostName": "", "SerialNumber": "CN701636AB0013",
+        "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem", "TrustedModules":
+        [{"Status": {"State": "Disabled"}}], "IndicatorLED": "Off", "SKU": "", "MemorySummary":
+        {"TotalSystemMemoryGiB": 32.0, "Status": {"State": "Enabled", "Health": null,
+        "HealthRollup": null}, "MemoryMirroring": "System"}, "Model": "DSS9630M",
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1", "Id": "System.Embedded.1",
+        "Bios": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"}, "SecureBoot":
+        {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"}, "ProcessorSummary":
+        {"Status": {"State": "Enabled", "Health": null, "HealthRollup": null}, "Count":
+        2, "Model": ""}, "SystemType": "Physical", "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+        "PartNumber": "033RF3X04", "BiosVersion": "0.4.8", "EthernetInterfaces": {"@odata.id":
+        "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"}, "Description":
+        "Computer System which represents a machine (physical or virtual) and the
+        local resources such as memory, cpu and other devices that can be accessed
+        from that machine.", "Actions": {"#ComputerSystem.Reset": {"target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+        "ResetType@Redfish.AllowableValues": ["On", "ForceOff", "GracefulRestart",
+        "GracefulShutdown", "PushPowerButton", "Nmi"]}}, "Boot": {"UefiTargetBootSourceOverride":
+        "", "BootSourceOverrideTarget": "None", "BootSourceOverrideTarget@Redfish.AllowableValues":
+        ["None", "Pxe", "Floppy", "Cd", "Hdd", "BiosSetup", "Utilities", "UefiTarget",
+        "SDCard", "UefiHttp"], "BootSourceOverrideEnabled": "Once", "BootSourceOverrideMode":
+        "UEFI"}, "Status": {"State": "StandbyOffline", "Health": "OK", "HealthRollup":
+        "OK"}}'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+- request:
+    method: post
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset
+    body:
+      encoding: UTF-8
+      string: '{"ResetType":"ForceOff"}'
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b94407d9-d5dc-4ba3-8689-bc9f11a195ec
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      Date:
+      - Mon, 04 Jun 2018 10:23:19 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_on/powers_on_the_system.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_on/powers_on_the_system.yml
@@ -1,0 +1,191 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      Date:
+      - Mon, 04 Jun 2018 10:23:19 GMT
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.context": "/redfish/v1/$metadata#ServiceRoot.ServiceRoot",
+        "@odata.id": "/redfish/v1", "@odata.type": "#ServiceRoot.v1_1_0.ServiceRoot",
+        "AccountService": {"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},
+        "Chassis": {"@odata.id": "/redfish/v1/Chassis"}, "Description": "Root Service",
+        "EventService": {"@odata.id": "/redfish/v1/EventService"}, "Id": "RootService",
+        "JsonSchemas": {"@odata.id": "/redfish/v1/JSONSchemas"}, "Links": {"Sessions":
+        {"@odata.id": "/redfish/v1/Sessions"}}, "Managers": {"@odata.id": "/redfish/v1/Managers"},
+        "Name": "Root Service", "Oem": {"Dell": {"@odata.type": "/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot",
+        "IsBranded": 0, "ManagerMACAddress": "10:98:36:a9:05:b0", "ServiceTag": ""}},
+        "RedfishVersion": "1.0.2", "Registries": {"@odata.id": "/redfish/v1/Registries"},
+        "SessionService": {"@odata.id": "/redfish/v1/SessionService"}, "Systems":
+        {"@odata.id": "/redfish/v1/Systems"}, "Tasks": {"@odata.id": "/redfish/v1/TaskService"},
+        "UpdateService": {"@odata.id": "/redfish/v1/UpdateService"}}'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+- request:
+    method: post
+    uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
+    body:
+      encoding: UTF-8
+      string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      Date:
+      - Mon, 04 Jun 2018 10:23:19 GMT
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+      Location:
+      - "/redfish/v1/Sessions/c8694d10-863e-4a0e-9613-da125e0d0beb"
+      X-Auth-Token:
+      - e190d3c5-6791-4dba-8ed8-f7fd306e239a
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.context": "/redfish/v1/$metadata#Session.Session", "@odata.type":
+        "#Session.v1_0_0.Session", "Name": "User Session", "Description": "User Session",
+        "UserName": "REDFISH_USERID", "@odata.id": "/redfish/v1/Sessions/c8694d10-863e-4a0e-9613-da125e0d0beb",
+        "Id": "c8694d10-863e-4a0e-9613-da125e0d0beb"}'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - e190d3c5-6791-4dba-8ed8-f7fd306e239a
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      Date:
+      - Mon, 04 Jun 2018 10:23:19 GMT
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"SimpleStorage": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},
+        "Links": {"CooledBy@odata.count": 12, "PoweredBy@odata.count": 0, "Oem": {"Dell":
+        {"BootSources": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"},
+        "@odata.type": "#Dell.v1_0_0.BootSources"}}, "ManagedBy": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}],
+        "Chassis": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1"}], "Chassis@odata.count":
+        1, "PoweredBy": [], "CooledBy": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],
+        "ManagedBy@odata.count": 1}, "Processors": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"},
+        "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+        "Manufacturer": "Dell Inc.", "PowerState": "Off", "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        "Name": "System", "AssetTag": "", "HostName": "", "SerialNumber": "CN701636AB0013",
+        "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem", "TrustedModules":
+        [{"Status": {"State": "Disabled"}}], "IndicatorLED": "Off", "SKU": "", "MemorySummary":
+        {"TotalSystemMemoryGiB": 32.0, "Status": {"State": "Enabled", "Health": null,
+        "HealthRollup": null}, "MemoryMirroring": "System"}, "Model": "DSS9630M",
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1", "Id": "System.Embedded.1",
+        "Bios": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"}, "SecureBoot":
+        {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"}, "ProcessorSummary":
+        {"Status": {"State": "Enabled", "Health": null, "HealthRollup": null}, "Count":
+        2, "Model": ""}, "SystemType": "Physical", "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+        "PartNumber": "033RF3X04", "BiosVersion": "0.4.8", "EthernetInterfaces": {"@odata.id":
+        "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"}, "Description":
+        "Computer System which represents a machine (physical or virtual) and the
+        local resources such as memory, cpu and other devices that can be accessed
+        from that machine.", "Actions": {"#ComputerSystem.Reset": {"target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+        "ResetType@Redfish.AllowableValues": ["On", "ForceOff", "GracefulRestart",
+        "GracefulShutdown", "PushPowerButton", "Nmi"]}}, "Boot": {"UefiTargetBootSourceOverride":
+        "", "BootSourceOverrideTarget": "None", "BootSourceOverrideTarget@Redfish.AllowableValues":
+        ["None", "Pxe", "Floppy", "Cd", "Hdd", "BiosSetup", "Utilities", "UefiTarget",
+        "SDCard", "UefiHttp"], "BootSourceOverrideEnabled": "Once", "BootSourceOverrideMode":
+        "UEFI"}, "Status": {"State": "StandbyOffline", "Health": "OK", "HealthRollup":
+        "OK"}}'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+- request:
+    method: post
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset
+    body:
+      encoding: UTF-8
+      string: '{"ResetType":"On"}'
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - e190d3c5-6791-4dba-8ed8-f7fd306e239a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      Date:
+      - Mon, 04 Jun 2018 10:23:19 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_restart/restarts_the_system.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_restart/restarts_the_system.yml
@@ -1,0 +1,191 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      Date:
+      - Mon, 04 Jun 2018 10:23:19 GMT
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.context": "/redfish/v1/$metadata#ServiceRoot.ServiceRoot",
+        "@odata.id": "/redfish/v1", "@odata.type": "#ServiceRoot.v1_1_0.ServiceRoot",
+        "AccountService": {"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},
+        "Chassis": {"@odata.id": "/redfish/v1/Chassis"}, "Description": "Root Service",
+        "EventService": {"@odata.id": "/redfish/v1/EventService"}, "Id": "RootService",
+        "JsonSchemas": {"@odata.id": "/redfish/v1/JSONSchemas"}, "Links": {"Sessions":
+        {"@odata.id": "/redfish/v1/Sessions"}}, "Managers": {"@odata.id": "/redfish/v1/Managers"},
+        "Name": "Root Service", "Oem": {"Dell": {"@odata.type": "/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot",
+        "IsBranded": 0, "ManagerMACAddress": "10:98:36:a9:05:b0", "ServiceTag": ""}},
+        "RedfishVersion": "1.0.2", "Registries": {"@odata.id": "/redfish/v1/Registries"},
+        "SessionService": {"@odata.id": "/redfish/v1/SessionService"}, "Systems":
+        {"@odata.id": "/redfish/v1/Systems"}, "Tasks": {"@odata.id": "/redfish/v1/TaskService"},
+        "UpdateService": {"@odata.id": "/redfish/v1/UpdateService"}}'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+- request:
+    method: post
+    uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
+    body:
+      encoding: UTF-8
+      string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      Date:
+      - Mon, 04 Jun 2018 10:23:19 GMT
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+      Location:
+      - "/redfish/v1/Sessions/ad59416d-d962-4b5a-9d42-22b31d71d3dc"
+      X-Auth-Token:
+      - 6196300e-364c-444e-9866-dd3adbd53eeb
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.context": "/redfish/v1/$metadata#Session.Session", "@odata.type":
+        "#Session.v1_0_0.Session", "Name": "User Session", "Description": "User Session",
+        "UserName": "REDFISH_USERID", "@odata.id": "/redfish/v1/Sessions/ad59416d-d962-4b5a-9d42-22b31d71d3dc",
+        "Id": "ad59416d-d962-4b5a-9d42-22b31d71d3dc"}'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 6196300e-364c-444e-9866-dd3adbd53eeb
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      Date:
+      - Mon, 04 Jun 2018 10:23:19 GMT
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"SimpleStorage": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},
+        "Links": {"CooledBy@odata.count": 12, "PoweredBy@odata.count": 0, "Oem": {"Dell":
+        {"BootSources": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"},
+        "@odata.type": "#Dell.v1_0_0.BootSources"}}, "ManagedBy": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}],
+        "Chassis": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1"}], "Chassis@odata.count":
+        1, "PoweredBy": [], "CooledBy": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],
+        "ManagedBy@odata.count": 1}, "Processors": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"},
+        "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+        "Manufacturer": "Dell Inc.", "PowerState": "Off", "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        "Name": "System", "AssetTag": "", "HostName": "", "SerialNumber": "CN701636AB0013",
+        "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem", "TrustedModules":
+        [{"Status": {"State": "Disabled"}}], "IndicatorLED": "Off", "SKU": "", "MemorySummary":
+        {"TotalSystemMemoryGiB": 32.0, "Status": {"State": "Enabled", "Health": null,
+        "HealthRollup": null}, "MemoryMirroring": "System"}, "Model": "DSS9630M",
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1", "Id": "System.Embedded.1",
+        "Bios": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"}, "SecureBoot":
+        {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"}, "ProcessorSummary":
+        {"Status": {"State": "Enabled", "Health": null, "HealthRollup": null}, "Count":
+        2, "Model": ""}, "SystemType": "Physical", "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+        "PartNumber": "033RF3X04", "BiosVersion": "0.4.8", "EthernetInterfaces": {"@odata.id":
+        "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"}, "Description":
+        "Computer System which represents a machine (physical or virtual) and the
+        local resources such as memory, cpu and other devices that can be accessed
+        from that machine.", "Actions": {"#ComputerSystem.Reset": {"target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+        "ResetType@Redfish.AllowableValues": ["On", "ForceOff", "GracefulRestart",
+        "GracefulShutdown", "PushPowerButton", "Nmi"]}}, "Boot": {"UefiTargetBootSourceOverride":
+        "", "BootSourceOverrideTarget": "None", "BootSourceOverrideTarget@Redfish.AllowableValues":
+        ["None", "Pxe", "Floppy", "Cd", "Hdd", "BiosSetup", "Utilities", "UefiTarget",
+        "SDCard", "UefiHttp"], "BootSourceOverrideEnabled": "Once", "BootSourceOverrideMode":
+        "UEFI"}, "Status": {"State": "StandbyOffline", "Health": "OK", "HealthRollup":
+        "OK"}}'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+- request:
+    method: post
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset
+    body:
+      encoding: UTF-8
+      string: '{"ResetType":"GracefulRestart"}'
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 6196300e-364c-444e-9866-dd3adbd53eeb
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      Date:
+      - Mon, 04 Jun 2018 10:23:19 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_restart_now/restarts_the_system_immediately.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_restart_now/restarts_the_system_immediately.yml
@@ -1,0 +1,191 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      Date:
+      - Mon, 04 Jun 2018 10:23:19 GMT
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.context": "/redfish/v1/$metadata#ServiceRoot.ServiceRoot",
+        "@odata.id": "/redfish/v1", "@odata.type": "#ServiceRoot.v1_1_0.ServiceRoot",
+        "AccountService": {"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},
+        "Chassis": {"@odata.id": "/redfish/v1/Chassis"}, "Description": "Root Service",
+        "EventService": {"@odata.id": "/redfish/v1/EventService"}, "Id": "RootService",
+        "JsonSchemas": {"@odata.id": "/redfish/v1/JSONSchemas"}, "Links": {"Sessions":
+        {"@odata.id": "/redfish/v1/Sessions"}}, "Managers": {"@odata.id": "/redfish/v1/Managers"},
+        "Name": "Root Service", "Oem": {"Dell": {"@odata.type": "/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot",
+        "IsBranded": 0, "ManagerMACAddress": "10:98:36:a9:05:b0", "ServiceTag": ""}},
+        "RedfishVersion": "1.0.2", "Registries": {"@odata.id": "/redfish/v1/Registries"},
+        "SessionService": {"@odata.id": "/redfish/v1/SessionService"}, "Systems":
+        {"@odata.id": "/redfish/v1/Systems"}, "Tasks": {"@odata.id": "/redfish/v1/TaskService"},
+        "UpdateService": {"@odata.id": "/redfish/v1/UpdateService"}}'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+- request:
+    method: post
+    uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
+    body:
+      encoding: UTF-8
+      string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      Date:
+      - Mon, 04 Jun 2018 10:23:19 GMT
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+      Location:
+      - "/redfish/v1/Sessions/2a16495e-31ec-48eb-8c03-44c478f5efff"
+      X-Auth-Token:
+      - a94f8c52-0ae2-49a3-baf0-7a2eba764c31
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.context": "/redfish/v1/$metadata#Session.Session", "@odata.type":
+        "#Session.v1_0_0.Session", "Name": "User Session", "Description": "User Session",
+        "UserName": "REDFISH_USERID", "@odata.id": "/redfish/v1/Sessions/2a16495e-31ec-48eb-8c03-44c478f5efff",
+        "Id": "2a16495e-31ec-48eb-8c03-44c478f5efff"}'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - a94f8c52-0ae2-49a3-baf0-7a2eba764c31
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      Date:
+      - Mon, 04 Jun 2018 10:23:19 GMT
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"SimpleStorage": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},
+        "Links": {"CooledBy@odata.count": 12, "PoweredBy@odata.count": 0, "Oem": {"Dell":
+        {"BootSources": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"},
+        "@odata.type": "#Dell.v1_0_0.BootSources"}}, "ManagedBy": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}],
+        "Chassis": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1"}], "Chassis@odata.count":
+        1, "PoweredBy": [], "CooledBy": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],
+        "ManagedBy@odata.count": 1}, "Processors": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"},
+        "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+        "Manufacturer": "Dell Inc.", "PowerState": "Off", "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        "Name": "System", "AssetTag": "", "HostName": "", "SerialNumber": "CN701636AB0013",
+        "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem", "TrustedModules":
+        [{"Status": {"State": "Disabled"}}], "IndicatorLED": "Off", "SKU": "", "MemorySummary":
+        {"TotalSystemMemoryGiB": 32.0, "Status": {"State": "Enabled", "Health": null,
+        "HealthRollup": null}, "MemoryMirroring": "System"}, "Model": "DSS9630M",
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1", "Id": "System.Embedded.1",
+        "Bios": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"}, "SecureBoot":
+        {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"}, "ProcessorSummary":
+        {"Status": {"State": "Enabled", "Health": null, "HealthRollup": null}, "Count":
+        2, "Model": ""}, "SystemType": "Physical", "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+        "PartNumber": "033RF3X04", "BiosVersion": "0.4.8", "EthernetInterfaces": {"@odata.id":
+        "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"}, "Description":
+        "Computer System which represents a machine (physical or virtual) and the
+        local resources such as memory, cpu and other devices that can be accessed
+        from that machine.", "Actions": {"#ComputerSystem.Reset": {"target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+        "ResetType@Redfish.AllowableValues": ["On", "ForceOff", "GracefulRestart",
+        "GracefulShutdown", "PushPowerButton", "Nmi"]}}, "Boot": {"UefiTargetBootSourceOverride":
+        "", "BootSourceOverrideTarget": "None", "BootSourceOverrideTarget@Redfish.AllowableValues":
+        ["None", "Pxe", "Floppy", "Cd", "Hdd", "BiosSetup", "Utilities", "UefiTarget",
+        "SDCard", "UefiHttp"], "BootSourceOverrideEnabled": "Once", "BootSourceOverrideMode":
+        "UEFI"}, "Status": {"State": "StandbyOffline", "Health": "OK", "HealthRollup":
+        "OK"}}'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+- request:
+    method: post
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset
+    body:
+      encoding: UTF-8
+      string: '{"ResetType":"ForceRestart"}'
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - a94f8c52-0ae2-49a3-baf0-7a2eba764c31
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      Date:
+      - Mon, 04 Jun 2018 10:23:19 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
This commit implements parts of the functionality that is used by the
power operations controls, exposed in physical server UI.

@miq-bot add_label wip