### PR TITLE
Add computer systems to inventory

### DIFF
--- a/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
@@ -27,6 +27,7 @@ module ManageIQ::Providers::Redfish
           :location_led_state     => s["IndicatorLED"],
           :physical_rack_id       => 0
         )
+        persister.computer_systems.build(:managed_entity => server)
       end
     end
 

--- a/app/models/manageiq/providers/redfish/inventory/persister/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/inventory/persister/physical_infra_manager.rb
@@ -4,6 +4,7 @@ module ManageIQ::Providers::Redfish
       collections = %i(
         physical_servers
         physical_server_details
+        computer_systems
       )
       add_inventory_collections(physical_infra, collections)
     end

--- a/app/models/manageiq/providers/redfish/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager.rb
@@ -12,6 +12,9 @@ module ManageIQ::Providers::Redfish
              :source     => :asset_detail,
              :through    => :physical_servers,
              :as         => :physical_server
+    has_many :computer_systems,
+             :through => :physical_servers,
+             :as      => :computer_system
 
     def self.ems_type
       @ems_type ||= "redfish_ph_infra".freeze

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
@@ -24,6 +24,7 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
     expect(ems.physical_servers.count).to eq(1)
     expect(ems.physical_servers.map(&:ems_ref)).to match_array([server_id])
     expect(ems.physical_server_details.count).to eq(1)
+    expect(ems.computer_systems.count).to eq(1)
   end
 
   def assert_physical_servers


### PR DESCRIPTION
Since computer systems are in 1:1 relation with the physical servers
and carry no data on its own, we add them to the database at the same
time as the servers.

@miq-bot assign @gtanzillo 
@miq-bot add_reviewer @gberginc 
@miq-bot add_reviewer @matejart 