### PR TITLE
Add hardware inventory refresh

### DIFF
--- a/app/models/manageiq/providers/redfish/inventory/collector/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/inventory/collector/physical_infra_manager.rb
@@ -8,6 +8,10 @@ module ManageIQ::Providers::Redfish
       rf_client.Systems.Members.collect { |s| get_server_location(s) }
     end
 
+    def hardwares
+      rf_client.Systems.Members.collect { |s| get_server_hardware(s) }
+    end
+
     private
 
     def get_server_location(server)
@@ -21,6 +25,46 @@ module ManageIQ::Providers::Redfish
       chassis.reduce(loc) do |acc, c|
         acc.merge!(c.respond_to?(:Location) ? c.Location.raw : {})
       end
+    end
+
+    def get_server_hardware(server)
+      {
+        :server_id => server["@odata.id"],
+        :memory_mb => get_server_memory_mb(server),
+        :cpu_cores => get_server_cpu_core_count(server),
+        :capacity  => get_server_disk_capacity(server),
+      }
+    end
+
+    def get_server_memory_mb(server)
+      (server.MemorySummary&.TotalSystemMemoryGiB || 0) * 1024
+    end
+
+    def get_server_cpu_core_count(server)
+      members = server.Processors&.Members || []
+      members.reduce(0) { |acc, p| acc + (p.TotalCores || 0) }
+    end
+
+    def get_server_disk_capacity(server)
+      get_simple_storage_sum(server) + get_storage_sum(server)
+    end
+
+    def get_simple_storage_sum(server)
+      members = server.SimpleStorage&.Members || []
+      members.reduce(0) { |acc, s| acc + get_simple_storage_capacity(s) }
+    end
+
+    def get_simple_storage_capacity(storage)
+      storage.Devices.reduce(0) { |acc, d| acc + (d.CapacityBytes || 0) }
+    end
+
+    def get_storage_sum(server)
+      members = server.Storage&.Members || []
+      members.reduce(0) { |acc, s| acc + get_storage_capacity(s) }
+    end
+
+    def get_storage_capacity(storage)
+      storage.Drives.reduce(0) { |acc, d| acc + (d.CapacityBytes || 0) }
     end
   end
 end

--- a/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
@@ -3,6 +3,7 @@ module ManageIQ::Providers::Redfish
     def parse
       physical_servers
       physical_server_details
+      hardwares
     end
 
     private
@@ -60,6 +61,19 @@ module ManageIQ::Providers::Redfish
 
     def get_rack(detail)
       detail.dig("Placement", "Rack") || ""
+    end
+
+    def hardwares
+      collector.hardwares.each do |h|
+        server = persister.physical_servers.find_or_build(h[:server_id])
+        computer = persister.computer_systems.find_or_build(server)
+        hardware = persister.hardwares.find_or_build(computer)
+        hardware.assign_attributes(
+          :disk_capacity   => h[:capacity],
+          :memory_mb       => h[:memory_mb],
+          :cpu_total_cores => h[:cpu_cores]
+        )
+      end
     end
   end
 end

--- a/app/models/manageiq/providers/redfish/inventory/persister/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/inventory/persister/physical_infra_manager.rb
@@ -5,6 +5,7 @@ module ManageIQ::Providers::Redfish
         physical_servers
         physical_server_details
         computer_systems
+        hardwares
       )
       add_inventory_collections(physical_infra, collections)
     end

--- a/app/models/manageiq/providers/redfish/inventory_collection_default/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/inventory_collection_default/physical_infra_manager.rb
@@ -38,5 +38,16 @@ module ManageIQ::Providers::Redfish
       }
       super(attributes.merge(extra_attributes))
     end
+
+    def self.hardwares(extra_attributes = {})
+      attributes = {
+        :inventory_object_attributes => %i(
+          disk_capacity
+          memory_mb
+          cpu_total_cores
+        )
+      }
+      super(attributes.merge(extra_attributes))
+    end
   end
 end

--- a/app/models/manageiq/providers/redfish/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager.rb
@@ -15,6 +15,9 @@ module ManageIQ::Providers::Redfish
     has_many :computer_systems,
              :through => :physical_servers,
              :as      => :computer_system
+    has_many :hardwares,
+             :through => :physical_servers,
+             :as      => :hardware
 
     def self.ems_type
       @ems_type ||= "redfish_ph_infra".freeze

--- a/spec/models/manageiq/providers/redfish/inventory/collector/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redfish/inventory/collector/physical_infra_manager_spec.rb
@@ -44,4 +44,35 @@ describe ManageIQ::Providers::Redfish::Inventory::Collector::PhysicalInfraManage
         .to eq(:server_id => "sid", "a" => "parent", "b" => "child")
     end
   end
+
+  context "#get_server_hardware" do
+    let(:server_data) do
+      cpu_cores = [{ "TotalCores" => 3 }, { "TotalCores" => 2 }]
+      devices = [{ "Devices" => [{ "CapacityBytes" => 123 }] }]
+      drives = [
+        { "Drives" => [{ "CapacityBytes" => 321 }] },
+        { "Drives" => [{ "CapacityBytes" => 432 }] }
+      ]
+      {
+        "@odata.id"     => "server_id",
+        "MemorySummary" => { "TotalSystemMemoryGiB" => 3 },
+        "Processors"    => { "Members" => cpu_cores },
+        "SimpleStorage" => { "Members" => devices },
+        "Storage"       => { "Members" => drives }
+      }
+    end
+    let(:specs) do
+      {
+        :server_id => "server_id",
+        :memory_mb => 3072,
+        :cpu_cores => 5,
+        :capacity  => 876
+      }
+    end
+
+    it "sums up hardware specifications" do
+      server = RedfishClient::Resource.new(nil, :content => server_data)
+      expect(collector.send(:get_server_hardware, server)).to eq(specs)
+    end
+  end
 end

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
@@ -16,6 +16,7 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
         assert_ems
         assert_physical_servers
         assert_physical_server_details
+        assert_hardwares
       end
     end
   end
@@ -25,6 +26,7 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
     expect(ems.physical_servers.map(&:ems_ref)).to match_array([server_id])
     expect(ems.physical_server_details.count).to eq(1)
     expect(ems.computer_systems.count).to eq(1)
+    expect(ems.hardwares.count).to eq(1)
   end
 
   def assert_physical_servers
@@ -55,6 +57,15 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
     #                 meaningful test.
     expect(d).to have_attributes(
       :resource_type => "PhysicalServer"
+    )
+  end
+
+  def assert_hardwares
+    h = Hardware.first
+    expect(h).to have_attributes(
+      :disk_capacity   => 0,
+      :memory_mb       => 32_768,
+      :cpu_total_cores => 40
     )
   end
 end

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_blink_loc_led/makes_location_LED_start_blinking.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_blink_loc_led/makes_location_LED_start_blinking.yml
@@ -16,33 +16,27 @@ http_interactions:
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
-      Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
-      Date:
-      - Fri, 08 Jun 2018 08:27:27 GMT
-      Odata-Version:
-      - '4.0'
       Content-Type:
       - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Wed, 13 Jun 2018 13:52:59 GMT
+      Content-Length:
+      - '1000'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context": "/redfish/v1/$metadata#ServiceRoot.ServiceRoot",
-        "@odata.id": "/redfish/v1", "@odata.type": "#ServiceRoot.v1_1_0.ServiceRoot",
-        "AccountService": {"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},
-        "Chassis": {"@odata.id": "/redfish/v1/Chassis"}, "Description": "Root Service",
-        "EventService": {"@odata.id": "/redfish/v1/EventService"}, "Id": "RootService",
-        "JsonSchemas": {"@odata.id": "/redfish/v1/JSONSchemas"}, "Links": {"Sessions":
-        {"@odata.id": "/redfish/v1/Sessions"}}, "Managers": {"@odata.id": "/redfish/v1/Managers"},
-        "Name": "Root Service", "Oem": {"Dell": {"@odata.type": "/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot",
-        "IsBranded": 0, "ManagerMACAddress": "10:98:36:a9:05:b0", "ServiceTag": ""}},
-        "RedfishVersion": "1.0.2", "Registries": {"@odata.id": "/redfish/v1/Registries"},
-        "SessionService": {"@odata.id": "/redfish/v1/SessionService"}, "Systems":
-        {"@odata.id": "/redfish/v1/Systems"}, "Tasks": {"@odata.id": "/redfish/v1/TaskService"},
-        "UpdateService": {"@odata.id": "/redfish/v1/UpdateService"}}'
+      string: '{"@odata.context":"/redfish/v1/$metadata#ServiceRoot.ServiceRoot","@odata.id":"/redfish/v1","@odata.type":"#ServiceRoot.v1_1_0.ServiceRoot","AccountService":{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},"Chassis":{"@odata.id":"/redfish/v1/Chassis"},"Description":"Root
+        Service","EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","JsonSchemas":{"@odata.id":"/redfish/v1/JSONSchemas"},"Links":{"Sessions":{"@odata.id":"/redfish/v1/Sessions"}},"Managers":{"@odata.id":"/redfish/v1/Managers"},"Name":"Root
+        Service","Oem":{"Dell":{"@odata.type":"/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot","IsBranded":0,"ManagerMACAddress":"10:98:36:a9:05:b0","ServiceTag":""}},"RedfishVersion":"1.0.2","Registries":{"@odata.id":"/redfish/v1/Registries"},"SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"Tasks":{"@odata.id":"/redfish/v1/TaskService"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}
+
+'
     http_version: 
-  recorded_at: Fri, 08 Jun 2018 08:27:27 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
@@ -61,28 +55,25 @@ http_interactions:
   response:
     status:
       code: 201
-      message: Created
+      message: 'Created '
     headers:
-      Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
-      Date:
-      - Fri, 08 Jun 2018 08:27:27 GMT
-      Odata-Version:
-      - '4.0'
       Content-Type:
       - application/json
-      Location:
-      - "/redfish/v1/Sessions/8f474888-af68-4711-b903-cb8b75341658"
       X-Auth-Token:
-      - 234b6128-f778-497a-82ad-4662f910b636
+      - dummy
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Wed, 13 Jun 2018 13:52:59 GMT
+      Content-Length:
+      - '71'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context": "/redfish/v1/$metadata#Session.Session", "@odata.type":
-        "#Session.v1_0_0.Session", "Name": "User Session", "Description": "User Session",
-        "UserName": "REDFISH_USERID", "@odata.id": "/redfish/v1/Sessions/8f474888-af68-4711-b903-cb8b75341658",
-        "Id": "8f474888-af68-4711-b903-cb8b75341658"}'
+      string: '{"Name":"User Session","Description":"User Session","UserName":"REDFISH_USERID"}'
     http_version: 
-  recorded_at: Fri, 08 Jun 2018 08:27:27 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -97,66 +88,199 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 234b6128-f778-497a-82ad-4662f910b636
+      - dummy
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - Apache/2.4
+      Cache-Control:
+      - no-cache
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Allow:
+      - POST,PATCH
+      Access-Control-Allow-Origin:
+      - "*"
       Date:
-      - Fri, 08 Jun 2018 08:27:27 GMT
+      - Sat, 20 May 2017 09:58:17 GMT
       Odata-Version:
       - '4.0'
-      Content-Type:
-      - application/json
+      Link:
+      - "</redfish/v1/Schemas/ComputerSystem.v1_1_0.json>;rel=describedby"
+      Content-Length:
+      - '5262'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"SimpleStorage": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},
-        "Links": {"CooledBy@odata.count": 12, "PoweredBy@odata.count": 0, "Oem": {"Dell":
-        {"BootSources": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"},
-        "@odata.type": "#Dell.v1_0_0.BootSources"}}, "ManagedBy": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}],
-        "Chassis": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1"}], "Chassis@odata.count":
-        1, "PoweredBy": [], "CooledBy": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],
-        "ManagedBy@odata.count": 1}, "Processors": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"},
-        "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
-        "Manufacturer": "Dell Inc.", "PowerState": "Off", "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
-        "Name": "System", "AssetTag": "", "HostName": "", "SerialNumber": "CN701636AB0013",
-        "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem", "TrustedModules":
-        [{"Status": {"State": "Disabled"}}], "IndicatorLED": "Lit", "SKU": "", "MemorySummary":
-        {"TotalSystemMemoryGiB": 32.0, "Status": {"State": "Enabled", "Health": null,
-        "HealthRollup": null}, "MemoryMirroring": "System"}, "Model": "DSS9630M",
-        "@odata.id": "/redfish/v1/Systems/System.Embedded.1", "Id": "System.Embedded.1",
-        "Bios": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"}, "SecureBoot":
-        {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"}, "ProcessorSummary":
-        {"Status": {"State": "Enabled", "Health": null, "HealthRollup": null}, "Count":
-        2, "Model": ""}, "SystemType": "Physical", "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
-        "PartNumber": "033RF3X04", "BiosVersion": "0.4.8", "EthernetInterfaces": {"@odata.id":
-        "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"}, "Description":
-        "Computer System which represents a machine (physical or virtual) and the
-        local resources such as memory, cpu and other devices that can be accessed
-        from that machine.", "Actions": {"#ComputerSystem.Reset": {"target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
-        "ResetType@Redfish.AllowableValues": ["On", "ForceOff", "GracefulRestart",
-        "GracefulShutdown", "PushPowerButton", "Nmi"]}}, "Boot": {"UefiTargetBootSourceOverride":
-        "", "BootSourceOverrideTarget": "None", "BootSourceOverrideTarget@Redfish.AllowableValues":
-        ["None", "Pxe", "Floppy", "Cd", "Hdd", "BiosSetup", "Utilities", "UefiTarget",
-        "SDCard", "UefiHttp"], "BootSourceOverrideEnabled": "Once", "BootSourceOverrideMode":
-        "UEFI"}, "Status": {"State": "StandbyOffline", "Health": "OK", "HealthRollup":
-        "OK"}}'
+      string: |-
+        {
+            "SimpleStorage": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"
+            },
+            "Links": {
+                "CooledBy@odata.count": 12,
+                "PoweredBy@odata.count": 0,
+                "Oem": {
+                    "Dell": {
+                        "BootSources": {
+                            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"
+                        },
+                        "@odata.type": "#Dell.v1_0_0.BootSources"
+                    }
+                },
+                "ManagedBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"
+                    }
+                ],
+                "Chassis": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1"
+                    }
+                ],
+                "Chassis@odata.count": 1,
+                "PoweredBy": [],
+                "CooledBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"
+                    }
+                ],
+                "ManagedBy@odata.count": 1
+            },
+            "Processors": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"
+            },
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "Manufacturer": "Dell Inc.",
+            "PowerState": "Off",
+            "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            "Name": "System",
+            "AssetTag": "",
+            "HostName": "",
+            "SerialNumber": "CN701636AB0013",
+            "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem",
+            "TrustedModules": [
+                {
+                    "Status": {
+                        "State": "Disabled"
+                    }
+                }
+            ],
+            "IndicatorLED": "Off",
+            "SKU": "",
+            "MemorySummary": {
+                "TotalSystemMemoryGiB": 32.0,
+                "Status": {
+                    "State": "Enabled",
+                    "Health": null,
+                    "HealthRollup": null
+                },
+                "MemoryMirroring": "System"
+            },
+            "Model": "DSS9630M",
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1",
+            "Id": "System.Embedded.1",
+            "Bios": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"
+            },
+            "SecureBoot": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"
+            },
+            "ProcessorSummary": {
+                "Status": {
+                    "State": "Enabled",
+                    "Health": null,
+                    "HealthRollup": null
+                },
+                "Count": 2,
+                "Model": ""
+            },
+            "SystemType": "Physical",
+            "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+            "PartNumber": "033RF3X04",
+            "BiosVersion": "0.4.8",
+            "EthernetInterfaces": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"
+            },
+            "Description": "Computer System which represents a machine (physical or virtual) and the local resources such as memory, cpu and other devices that can be accessed from that machine.",
+            "Actions": {
+                "#ComputerSystem.Reset": {
+                    "target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+                    "ResetType@Redfish.AllowableValues": [
+                        "On",
+                        "ForceOff",
+                        "GracefulRestart",
+                        "GracefulShutdown",
+                        "PushPowerButton",
+                        "Nmi"
+                    ]
+                }
+            },
+            "Boot": {
+                "UefiTargetBootSourceOverride": "",
+                "BootSourceOverrideTarget": "None",
+                "BootSourceOverrideTarget@Redfish.AllowableValues": [
+                    "None",
+                    "Pxe",
+                    "Floppy",
+                    "Cd",
+                    "Hdd",
+                    "BiosSetup",
+                    "Utilities",
+                    "UefiTarget",
+                    "SDCard",
+                    "UefiHttp"
+                ],
+                "BootSourceOverrideEnabled": "Once",
+                "BootSourceOverrideMode": "UEFI"
+            },
+            "Status": {
+                "State": "StandbyOffline",
+                "Health": "OK",
+                "HealthRollup": "OK"
+            }
+        }
     http_version: 
-  recorded_at: Fri, 08 Jun 2018 08:27:27 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
 - request:
     method: patch
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -171,66 +295,25 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 234b6128-f778-497a-82ad-4662f910b636
+      - dummy
       Content-Type:
       - application/json
   response:
     status:
-      code: 200
-      message: OK
+      code: 501
+      message: 'Not Implemented '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Fri, 08 Jun 2018 08:27:27 GMT
-      Odata-Version:
-      - '4.0'
-      Content-Type:
-      - application/json
+      - Wed, 13 Jun 2018 13:52:59 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"SimpleStorage": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},
-        "Links": {"CooledBy@odata.count": 12, "PoweredBy@odata.count": 0, "Oem": {"Dell":
-        {"BootSources": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"},
-        "@odata.type": "#Dell.v1_0_0.BootSources"}}, "ManagedBy": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}],
-        "Chassis": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1"}], "Chassis@odata.count":
-        1, "PoweredBy": [], "CooledBy": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],
-        "ManagedBy@odata.count": 1}, "Processors": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"},
-        "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
-        "Manufacturer": "Dell Inc.", "PowerState": "Off", "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
-        "Name": "System", "AssetTag": "", "HostName": "", "SerialNumber": "CN701636AB0013",
-        "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem", "TrustedModules":
-        [{"Status": {"State": "Disabled"}}], "IndicatorLED": "Blinking", "SKU": "",
-        "MemorySummary": {"TotalSystemMemoryGiB": 32.0, "Status": {"State": "Enabled",
-        "Health": null, "HealthRollup": null}, "MemoryMirroring": "System"}, "Model":
-        "DSS9630M", "@odata.id": "/redfish/v1/Systems/System.Embedded.1", "Id": "System.Embedded.1",
-        "Bios": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"}, "SecureBoot":
-        {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"}, "ProcessorSummary":
-        {"Status": {"State": "Enabled", "Health": null, "HealthRollup": null}, "Count":
-        2, "Model": ""}, "SystemType": "Physical", "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
-        "PartNumber": "033RF3X04", "BiosVersion": "0.4.8", "EthernetInterfaces": {"@odata.id":
-        "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"}, "Description":
-        "Computer System which represents a machine (physical or virtual) and the
-        local resources such as memory, cpu and other devices that can be accessed
-        from that machine.", "Actions": {"#ComputerSystem.Reset": {"target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
-        "ResetType@Redfish.AllowableValues": ["On", "ForceOff", "GracefulRestart",
-        "GracefulShutdown", "PushPowerButton", "Nmi"]}}, "Boot": {"UefiTargetBootSourceOverride":
-        "", "BootSourceOverrideTarget": "None", "BootSourceOverrideTarget@Redfish.AllowableValues":
-        ["None", "Pxe", "Floppy", "Cd", "Hdd", "BiosSetup", "Utilities", "UefiTarget",
-        "SDCard", "UefiHttp"], "BootSourceOverrideEnabled": "Once", "BootSourceOverrideMode":
-        "UEFI"}, "Status": {"State": "StandbyOffline", "Health": "OK", "HealthRollup":
-        "OK"}}'
+      string: ''
     http_version: 
-  recorded_at: Fri, 08 Jun 2018 08:27:27 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_off/powers_off_the_system.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_off/powers_off_the_system.yml
@@ -16,33 +16,27 @@ http_interactions:
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
-      Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
-      Date:
-      - Mon, 04 Jun 2018 10:23:19 GMT
-      Odata-Version:
-      - '4.0'
       Content-Type:
       - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Wed, 13 Jun 2018 13:52:57 GMT
+      Content-Length:
+      - '1000'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context": "/redfish/v1/$metadata#ServiceRoot.ServiceRoot",
-        "@odata.id": "/redfish/v1", "@odata.type": "#ServiceRoot.v1_1_0.ServiceRoot",
-        "AccountService": {"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},
-        "Chassis": {"@odata.id": "/redfish/v1/Chassis"}, "Description": "Root Service",
-        "EventService": {"@odata.id": "/redfish/v1/EventService"}, "Id": "RootService",
-        "JsonSchemas": {"@odata.id": "/redfish/v1/JSONSchemas"}, "Links": {"Sessions":
-        {"@odata.id": "/redfish/v1/Sessions"}}, "Managers": {"@odata.id": "/redfish/v1/Managers"},
-        "Name": "Root Service", "Oem": {"Dell": {"@odata.type": "/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot",
-        "IsBranded": 0, "ManagerMACAddress": "10:98:36:a9:05:b0", "ServiceTag": ""}},
-        "RedfishVersion": "1.0.2", "Registries": {"@odata.id": "/redfish/v1/Registries"},
-        "SessionService": {"@odata.id": "/redfish/v1/SessionService"}, "Systems":
-        {"@odata.id": "/redfish/v1/Systems"}, "Tasks": {"@odata.id": "/redfish/v1/TaskService"},
-        "UpdateService": {"@odata.id": "/redfish/v1/UpdateService"}}'
+      string: '{"@odata.context":"/redfish/v1/$metadata#ServiceRoot.ServiceRoot","@odata.id":"/redfish/v1","@odata.type":"#ServiceRoot.v1_1_0.ServiceRoot","AccountService":{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},"Chassis":{"@odata.id":"/redfish/v1/Chassis"},"Description":"Root
+        Service","EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","JsonSchemas":{"@odata.id":"/redfish/v1/JSONSchemas"},"Links":{"Sessions":{"@odata.id":"/redfish/v1/Sessions"}},"Managers":{"@odata.id":"/redfish/v1/Managers"},"Name":"Root
+        Service","Oem":{"Dell":{"@odata.type":"/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot","IsBranded":0,"ManagerMACAddress":"10:98:36:a9:05:b0","ServiceTag":""}},"RedfishVersion":"1.0.2","Registries":{"@odata.id":"/redfish/v1/Registries"},"SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"Tasks":{"@odata.id":"/redfish/v1/TaskService"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}
+
+'
     http_version: 
-  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:57 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
@@ -61,28 +55,25 @@ http_interactions:
   response:
     status:
       code: 201
-      message: Created
+      message: 'Created '
     headers:
-      Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
-      Date:
-      - Mon, 04 Jun 2018 10:23:19 GMT
-      Odata-Version:
-      - '4.0'
       Content-Type:
       - application/json
-      Location:
-      - "/redfish/v1/Sessions/a7d2f27a-c64d-491c-ace1-508923551fcd"
       X-Auth-Token:
-      - 21161704-7ba8-421f-ae23-7f1464e261f3
+      - dummy
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Wed, 13 Jun 2018 13:52:57 GMT
+      Content-Length:
+      - '71'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context": "/redfish/v1/$metadata#Session.Session", "@odata.type":
-        "#Session.v1_0_0.Session", "Name": "User Session", "Description": "User Session",
-        "UserName": "REDFISH_USERID", "@odata.id": "/redfish/v1/Sessions/a7d2f27a-c64d-491c-ace1-508923551fcd",
-        "Id": "a7d2f27a-c64d-491c-ace1-508923551fcd"}'
+      string: '{"Name":"User Session","Description":"User Session","UserName":"REDFISH_USERID"}'
     http_version: 
-  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:57 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -97,66 +88,199 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 21161704-7ba8-421f-ae23-7f1464e261f3
+      - dummy
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - Apache/2.4
+      Cache-Control:
+      - no-cache
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Allow:
+      - POST,PATCH
+      Access-Control-Allow-Origin:
+      - "*"
       Date:
-      - Mon, 04 Jun 2018 10:23:19 GMT
+      - Sat, 20 May 2017 09:58:17 GMT
       Odata-Version:
       - '4.0'
-      Content-Type:
-      - application/json
+      Link:
+      - "</redfish/v1/Schemas/ComputerSystem.v1_1_0.json>;rel=describedby"
+      Content-Length:
+      - '5262'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"SimpleStorage": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},
-        "Links": {"CooledBy@odata.count": 12, "PoweredBy@odata.count": 0, "Oem": {"Dell":
-        {"BootSources": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"},
-        "@odata.type": "#Dell.v1_0_0.BootSources"}}, "ManagedBy": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}],
-        "Chassis": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1"}], "Chassis@odata.count":
-        1, "PoweredBy": [], "CooledBy": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],
-        "ManagedBy@odata.count": 1}, "Processors": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"},
-        "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
-        "Manufacturer": "Dell Inc.", "PowerState": "Off", "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
-        "Name": "System", "AssetTag": "", "HostName": "", "SerialNumber": "CN701636AB0013",
-        "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem", "TrustedModules":
-        [{"Status": {"State": "Disabled"}}], "IndicatorLED": "Off", "SKU": "", "MemorySummary":
-        {"TotalSystemMemoryGiB": 32.0, "Status": {"State": "Enabled", "Health": null,
-        "HealthRollup": null}, "MemoryMirroring": "System"}, "Model": "DSS9630M",
-        "@odata.id": "/redfish/v1/Systems/System.Embedded.1", "Id": "System.Embedded.1",
-        "Bios": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"}, "SecureBoot":
-        {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"}, "ProcessorSummary":
-        {"Status": {"State": "Enabled", "Health": null, "HealthRollup": null}, "Count":
-        2, "Model": ""}, "SystemType": "Physical", "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
-        "PartNumber": "033RF3X04", "BiosVersion": "0.4.8", "EthernetInterfaces": {"@odata.id":
-        "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"}, "Description":
-        "Computer System which represents a machine (physical or virtual) and the
-        local resources such as memory, cpu and other devices that can be accessed
-        from that machine.", "Actions": {"#ComputerSystem.Reset": {"target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
-        "ResetType@Redfish.AllowableValues": ["On", "ForceOff", "GracefulRestart",
-        "GracefulShutdown", "PushPowerButton", "Nmi"]}}, "Boot": {"UefiTargetBootSourceOverride":
-        "", "BootSourceOverrideTarget": "None", "BootSourceOverrideTarget@Redfish.AllowableValues":
-        ["None", "Pxe", "Floppy", "Cd", "Hdd", "BiosSetup", "Utilities", "UefiTarget",
-        "SDCard", "UefiHttp"], "BootSourceOverrideEnabled": "Once", "BootSourceOverrideMode":
-        "UEFI"}, "Status": {"State": "StandbyOffline", "Health": "OK", "HealthRollup":
-        "OK"}}'
+      string: |-
+        {
+            "SimpleStorage": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"
+            },
+            "Links": {
+                "CooledBy@odata.count": 12,
+                "PoweredBy@odata.count": 0,
+                "Oem": {
+                    "Dell": {
+                        "BootSources": {
+                            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"
+                        },
+                        "@odata.type": "#Dell.v1_0_0.BootSources"
+                    }
+                },
+                "ManagedBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"
+                    }
+                ],
+                "Chassis": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1"
+                    }
+                ],
+                "Chassis@odata.count": 1,
+                "PoweredBy": [],
+                "CooledBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"
+                    }
+                ],
+                "ManagedBy@odata.count": 1
+            },
+            "Processors": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"
+            },
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "Manufacturer": "Dell Inc.",
+            "PowerState": "Off",
+            "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            "Name": "System",
+            "AssetTag": "",
+            "HostName": "",
+            "SerialNumber": "CN701636AB0013",
+            "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem",
+            "TrustedModules": [
+                {
+                    "Status": {
+                        "State": "Disabled"
+                    }
+                }
+            ],
+            "IndicatorLED": "Off",
+            "SKU": "",
+            "MemorySummary": {
+                "TotalSystemMemoryGiB": 32.0,
+                "Status": {
+                    "State": "Enabled",
+                    "Health": null,
+                    "HealthRollup": null
+                },
+                "MemoryMirroring": "System"
+            },
+            "Model": "DSS9630M",
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1",
+            "Id": "System.Embedded.1",
+            "Bios": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"
+            },
+            "SecureBoot": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"
+            },
+            "ProcessorSummary": {
+                "Status": {
+                    "State": "Enabled",
+                    "Health": null,
+                    "HealthRollup": null
+                },
+                "Count": 2,
+                "Model": ""
+            },
+            "SystemType": "Physical",
+            "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+            "PartNumber": "033RF3X04",
+            "BiosVersion": "0.4.8",
+            "EthernetInterfaces": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"
+            },
+            "Description": "Computer System which represents a machine (physical or virtual) and the local resources such as memory, cpu and other devices that can be accessed from that machine.",
+            "Actions": {
+                "#ComputerSystem.Reset": {
+                    "target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+                    "ResetType@Redfish.AllowableValues": [
+                        "On",
+                        "ForceOff",
+                        "GracefulRestart",
+                        "GracefulShutdown",
+                        "PushPowerButton",
+                        "Nmi"
+                    ]
+                }
+            },
+            "Boot": {
+                "UefiTargetBootSourceOverride": "",
+                "BootSourceOverrideTarget": "None",
+                "BootSourceOverrideTarget@Redfish.AllowableValues": [
+                    "None",
+                    "Pxe",
+                    "Floppy",
+                    "Cd",
+                    "Hdd",
+                    "BiosSetup",
+                    "Utilities",
+                    "UefiTarget",
+                    "SDCard",
+                    "UefiHttp"
+                ],
+                "BootSourceOverrideEnabled": "Once",
+                "BootSourceOverrideMode": "UEFI"
+            },
+            "Status": {
+                "State": "StandbyOffline",
+                "Health": "OK",
+                "HealthRollup": "OK"
+            }
+        }
     http_version: 
-  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:57 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset
@@ -171,21 +295,25 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 21161704-7ba8-421f-ae23-7f1464e261f3
+      - dummy
       Content-Type:
       - application/json
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 501
+      message: 'Not Implemented '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Mon, 04 Jun 2018 10:23:19 GMT
+      - Wed, 13 Jun 2018 13:52:57 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:57 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_off_now/powers_off_the_system_immediately.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_off_now/powers_off_the_system_immediately.yml
@@ -16,33 +16,27 @@ http_interactions:
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
-      Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
-      Date:
-      - Mon, 04 Jun 2018 10:23:19 GMT
-      Odata-Version:
-      - '4.0'
       Content-Type:
       - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Wed, 13 Jun 2018 13:52:57 GMT
+      Content-Length:
+      - '1000'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context": "/redfish/v1/$metadata#ServiceRoot.ServiceRoot",
-        "@odata.id": "/redfish/v1", "@odata.type": "#ServiceRoot.v1_1_0.ServiceRoot",
-        "AccountService": {"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},
-        "Chassis": {"@odata.id": "/redfish/v1/Chassis"}, "Description": "Root Service",
-        "EventService": {"@odata.id": "/redfish/v1/EventService"}, "Id": "RootService",
-        "JsonSchemas": {"@odata.id": "/redfish/v1/JSONSchemas"}, "Links": {"Sessions":
-        {"@odata.id": "/redfish/v1/Sessions"}}, "Managers": {"@odata.id": "/redfish/v1/Managers"},
-        "Name": "Root Service", "Oem": {"Dell": {"@odata.type": "/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot",
-        "IsBranded": 0, "ManagerMACAddress": "10:98:36:a9:05:b0", "ServiceTag": ""}},
-        "RedfishVersion": "1.0.2", "Registries": {"@odata.id": "/redfish/v1/Registries"},
-        "SessionService": {"@odata.id": "/redfish/v1/SessionService"}, "Systems":
-        {"@odata.id": "/redfish/v1/Systems"}, "Tasks": {"@odata.id": "/redfish/v1/TaskService"},
-        "UpdateService": {"@odata.id": "/redfish/v1/UpdateService"}}'
+      string: '{"@odata.context":"/redfish/v1/$metadata#ServiceRoot.ServiceRoot","@odata.id":"/redfish/v1","@odata.type":"#ServiceRoot.v1_1_0.ServiceRoot","AccountService":{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},"Chassis":{"@odata.id":"/redfish/v1/Chassis"},"Description":"Root
+        Service","EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","JsonSchemas":{"@odata.id":"/redfish/v1/JSONSchemas"},"Links":{"Sessions":{"@odata.id":"/redfish/v1/Sessions"}},"Managers":{"@odata.id":"/redfish/v1/Managers"},"Name":"Root
+        Service","Oem":{"Dell":{"@odata.type":"/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot","IsBranded":0,"ManagerMACAddress":"10:98:36:a9:05:b0","ServiceTag":""}},"RedfishVersion":"1.0.2","Registries":{"@odata.id":"/redfish/v1/Registries"},"SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"Tasks":{"@odata.id":"/redfish/v1/TaskService"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}
+
+'
     http_version: 
-  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:57 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
@@ -61,28 +55,25 @@ http_interactions:
   response:
     status:
       code: 201
-      message: Created
+      message: 'Created '
     headers:
-      Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
-      Date:
-      - Mon, 04 Jun 2018 10:23:19 GMT
-      Odata-Version:
-      - '4.0'
       Content-Type:
       - application/json
-      Location:
-      - "/redfish/v1/Sessions/a4a5ec46-452f-4ef8-b8f3-98d144da1821"
       X-Auth-Token:
-      - b94407d9-d5dc-4ba3-8689-bc9f11a195ec
+      - dummy
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Wed, 13 Jun 2018 13:52:57 GMT
+      Content-Length:
+      - '71'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context": "/redfish/v1/$metadata#Session.Session", "@odata.type":
-        "#Session.v1_0_0.Session", "Name": "User Session", "Description": "User Session",
-        "UserName": "REDFISH_USERID", "@odata.id": "/redfish/v1/Sessions/a4a5ec46-452f-4ef8-b8f3-98d144da1821",
-        "Id": "a4a5ec46-452f-4ef8-b8f3-98d144da1821"}'
+      string: '{"Name":"User Session","Description":"User Session","UserName":"REDFISH_USERID"}'
     http_version: 
-  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:57 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -97,66 +88,199 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - b94407d9-d5dc-4ba3-8689-bc9f11a195ec
+      - dummy
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - Apache/2.4
+      Cache-Control:
+      - no-cache
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Allow:
+      - POST,PATCH
+      Access-Control-Allow-Origin:
+      - "*"
       Date:
-      - Mon, 04 Jun 2018 10:23:19 GMT
+      - Sat, 20 May 2017 09:58:17 GMT
       Odata-Version:
       - '4.0'
-      Content-Type:
-      - application/json
+      Link:
+      - "</redfish/v1/Schemas/ComputerSystem.v1_1_0.json>;rel=describedby"
+      Content-Length:
+      - '5262'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"SimpleStorage": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},
-        "Links": {"CooledBy@odata.count": 12, "PoweredBy@odata.count": 0, "Oem": {"Dell":
-        {"BootSources": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"},
-        "@odata.type": "#Dell.v1_0_0.BootSources"}}, "ManagedBy": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}],
-        "Chassis": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1"}], "Chassis@odata.count":
-        1, "PoweredBy": [], "CooledBy": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],
-        "ManagedBy@odata.count": 1}, "Processors": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"},
-        "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
-        "Manufacturer": "Dell Inc.", "PowerState": "Off", "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
-        "Name": "System", "AssetTag": "", "HostName": "", "SerialNumber": "CN701636AB0013",
-        "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem", "TrustedModules":
-        [{"Status": {"State": "Disabled"}}], "IndicatorLED": "Off", "SKU": "", "MemorySummary":
-        {"TotalSystemMemoryGiB": 32.0, "Status": {"State": "Enabled", "Health": null,
-        "HealthRollup": null}, "MemoryMirroring": "System"}, "Model": "DSS9630M",
-        "@odata.id": "/redfish/v1/Systems/System.Embedded.1", "Id": "System.Embedded.1",
-        "Bios": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"}, "SecureBoot":
-        {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"}, "ProcessorSummary":
-        {"Status": {"State": "Enabled", "Health": null, "HealthRollup": null}, "Count":
-        2, "Model": ""}, "SystemType": "Physical", "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
-        "PartNumber": "033RF3X04", "BiosVersion": "0.4.8", "EthernetInterfaces": {"@odata.id":
-        "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"}, "Description":
-        "Computer System which represents a machine (physical or virtual) and the
-        local resources such as memory, cpu and other devices that can be accessed
-        from that machine.", "Actions": {"#ComputerSystem.Reset": {"target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
-        "ResetType@Redfish.AllowableValues": ["On", "ForceOff", "GracefulRestart",
-        "GracefulShutdown", "PushPowerButton", "Nmi"]}}, "Boot": {"UefiTargetBootSourceOverride":
-        "", "BootSourceOverrideTarget": "None", "BootSourceOverrideTarget@Redfish.AllowableValues":
-        ["None", "Pxe", "Floppy", "Cd", "Hdd", "BiosSetup", "Utilities", "UefiTarget",
-        "SDCard", "UefiHttp"], "BootSourceOverrideEnabled": "Once", "BootSourceOverrideMode":
-        "UEFI"}, "Status": {"State": "StandbyOffline", "Health": "OK", "HealthRollup":
-        "OK"}}'
+      string: |-
+        {
+            "SimpleStorage": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"
+            },
+            "Links": {
+                "CooledBy@odata.count": 12,
+                "PoweredBy@odata.count": 0,
+                "Oem": {
+                    "Dell": {
+                        "BootSources": {
+                            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"
+                        },
+                        "@odata.type": "#Dell.v1_0_0.BootSources"
+                    }
+                },
+                "ManagedBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"
+                    }
+                ],
+                "Chassis": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1"
+                    }
+                ],
+                "Chassis@odata.count": 1,
+                "PoweredBy": [],
+                "CooledBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"
+                    }
+                ],
+                "ManagedBy@odata.count": 1
+            },
+            "Processors": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"
+            },
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "Manufacturer": "Dell Inc.",
+            "PowerState": "Off",
+            "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            "Name": "System",
+            "AssetTag": "",
+            "HostName": "",
+            "SerialNumber": "CN701636AB0013",
+            "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem",
+            "TrustedModules": [
+                {
+                    "Status": {
+                        "State": "Disabled"
+                    }
+                }
+            ],
+            "IndicatorLED": "Off",
+            "SKU": "",
+            "MemorySummary": {
+                "TotalSystemMemoryGiB": 32.0,
+                "Status": {
+                    "State": "Enabled",
+                    "Health": null,
+                    "HealthRollup": null
+                },
+                "MemoryMirroring": "System"
+            },
+            "Model": "DSS9630M",
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1",
+            "Id": "System.Embedded.1",
+            "Bios": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"
+            },
+            "SecureBoot": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"
+            },
+            "ProcessorSummary": {
+                "Status": {
+                    "State": "Enabled",
+                    "Health": null,
+                    "HealthRollup": null
+                },
+                "Count": 2,
+                "Model": ""
+            },
+            "SystemType": "Physical",
+            "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+            "PartNumber": "033RF3X04",
+            "BiosVersion": "0.4.8",
+            "EthernetInterfaces": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"
+            },
+            "Description": "Computer System which represents a machine (physical or virtual) and the local resources such as memory, cpu and other devices that can be accessed from that machine.",
+            "Actions": {
+                "#ComputerSystem.Reset": {
+                    "target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+                    "ResetType@Redfish.AllowableValues": [
+                        "On",
+                        "ForceOff",
+                        "GracefulRestart",
+                        "GracefulShutdown",
+                        "PushPowerButton",
+                        "Nmi"
+                    ]
+                }
+            },
+            "Boot": {
+                "UefiTargetBootSourceOverride": "",
+                "BootSourceOverrideTarget": "None",
+                "BootSourceOverrideTarget@Redfish.AllowableValues": [
+                    "None",
+                    "Pxe",
+                    "Floppy",
+                    "Cd",
+                    "Hdd",
+                    "BiosSetup",
+                    "Utilities",
+                    "UefiTarget",
+                    "SDCard",
+                    "UefiHttp"
+                ],
+                "BootSourceOverrideEnabled": "Once",
+                "BootSourceOverrideMode": "UEFI"
+            },
+            "Status": {
+                "State": "StandbyOffline",
+                "Health": "OK",
+                "HealthRollup": "OK"
+            }
+        }
     http_version: 
-  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:57 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset
@@ -171,21 +295,25 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - b94407d9-d5dc-4ba3-8689-bc9f11a195ec
+      - dummy
       Content-Type:
       - application/json
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 501
+      message: 'Not Implemented '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Mon, 04 Jun 2018 10:23:19 GMT
+      - Wed, 13 Jun 2018 13:52:58 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:58 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_on/powers_on_the_system.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_on/powers_on_the_system.yml
@@ -16,33 +16,27 @@ http_interactions:
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
-      Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
-      Date:
-      - Mon, 04 Jun 2018 10:23:19 GMT
-      Odata-Version:
-      - '4.0'
       Content-Type:
       - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Wed, 13 Jun 2018 13:52:58 GMT
+      Content-Length:
+      - '1000'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context": "/redfish/v1/$metadata#ServiceRoot.ServiceRoot",
-        "@odata.id": "/redfish/v1", "@odata.type": "#ServiceRoot.v1_1_0.ServiceRoot",
-        "AccountService": {"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},
-        "Chassis": {"@odata.id": "/redfish/v1/Chassis"}, "Description": "Root Service",
-        "EventService": {"@odata.id": "/redfish/v1/EventService"}, "Id": "RootService",
-        "JsonSchemas": {"@odata.id": "/redfish/v1/JSONSchemas"}, "Links": {"Sessions":
-        {"@odata.id": "/redfish/v1/Sessions"}}, "Managers": {"@odata.id": "/redfish/v1/Managers"},
-        "Name": "Root Service", "Oem": {"Dell": {"@odata.type": "/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot",
-        "IsBranded": 0, "ManagerMACAddress": "10:98:36:a9:05:b0", "ServiceTag": ""}},
-        "RedfishVersion": "1.0.2", "Registries": {"@odata.id": "/redfish/v1/Registries"},
-        "SessionService": {"@odata.id": "/redfish/v1/SessionService"}, "Systems":
-        {"@odata.id": "/redfish/v1/Systems"}, "Tasks": {"@odata.id": "/redfish/v1/TaskService"},
-        "UpdateService": {"@odata.id": "/redfish/v1/UpdateService"}}'
+      string: '{"@odata.context":"/redfish/v1/$metadata#ServiceRoot.ServiceRoot","@odata.id":"/redfish/v1","@odata.type":"#ServiceRoot.v1_1_0.ServiceRoot","AccountService":{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},"Chassis":{"@odata.id":"/redfish/v1/Chassis"},"Description":"Root
+        Service","EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","JsonSchemas":{"@odata.id":"/redfish/v1/JSONSchemas"},"Links":{"Sessions":{"@odata.id":"/redfish/v1/Sessions"}},"Managers":{"@odata.id":"/redfish/v1/Managers"},"Name":"Root
+        Service","Oem":{"Dell":{"@odata.type":"/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot","IsBranded":0,"ManagerMACAddress":"10:98:36:a9:05:b0","ServiceTag":""}},"RedfishVersion":"1.0.2","Registries":{"@odata.id":"/redfish/v1/Registries"},"SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"Tasks":{"@odata.id":"/redfish/v1/TaskService"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}
+
+'
     http_version: 
-  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:58 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
@@ -61,28 +55,25 @@ http_interactions:
   response:
     status:
       code: 201
-      message: Created
+      message: 'Created '
     headers:
-      Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
-      Date:
-      - Mon, 04 Jun 2018 10:23:19 GMT
-      Odata-Version:
-      - '4.0'
       Content-Type:
       - application/json
-      Location:
-      - "/redfish/v1/Sessions/c8694d10-863e-4a0e-9613-da125e0d0beb"
       X-Auth-Token:
-      - e190d3c5-6791-4dba-8ed8-f7fd306e239a
+      - dummy
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Wed, 13 Jun 2018 13:52:58 GMT
+      Content-Length:
+      - '71'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context": "/redfish/v1/$metadata#Session.Session", "@odata.type":
-        "#Session.v1_0_0.Session", "Name": "User Session", "Description": "User Session",
-        "UserName": "REDFISH_USERID", "@odata.id": "/redfish/v1/Sessions/c8694d10-863e-4a0e-9613-da125e0d0beb",
-        "Id": "c8694d10-863e-4a0e-9613-da125e0d0beb"}'
+      string: '{"Name":"User Session","Description":"User Session","UserName":"REDFISH_USERID"}'
     http_version: 
-  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:58 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -97,66 +88,199 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - e190d3c5-6791-4dba-8ed8-f7fd306e239a
+      - dummy
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - Apache/2.4
+      Cache-Control:
+      - no-cache
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Allow:
+      - POST,PATCH
+      Access-Control-Allow-Origin:
+      - "*"
       Date:
-      - Mon, 04 Jun 2018 10:23:19 GMT
+      - Sat, 20 May 2017 09:58:17 GMT
       Odata-Version:
       - '4.0'
-      Content-Type:
-      - application/json
+      Link:
+      - "</redfish/v1/Schemas/ComputerSystem.v1_1_0.json>;rel=describedby"
+      Content-Length:
+      - '5262'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"SimpleStorage": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},
-        "Links": {"CooledBy@odata.count": 12, "PoweredBy@odata.count": 0, "Oem": {"Dell":
-        {"BootSources": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"},
-        "@odata.type": "#Dell.v1_0_0.BootSources"}}, "ManagedBy": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}],
-        "Chassis": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1"}], "Chassis@odata.count":
-        1, "PoweredBy": [], "CooledBy": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],
-        "ManagedBy@odata.count": 1}, "Processors": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"},
-        "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
-        "Manufacturer": "Dell Inc.", "PowerState": "Off", "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
-        "Name": "System", "AssetTag": "", "HostName": "", "SerialNumber": "CN701636AB0013",
-        "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem", "TrustedModules":
-        [{"Status": {"State": "Disabled"}}], "IndicatorLED": "Off", "SKU": "", "MemorySummary":
-        {"TotalSystemMemoryGiB": 32.0, "Status": {"State": "Enabled", "Health": null,
-        "HealthRollup": null}, "MemoryMirroring": "System"}, "Model": "DSS9630M",
-        "@odata.id": "/redfish/v1/Systems/System.Embedded.1", "Id": "System.Embedded.1",
-        "Bios": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"}, "SecureBoot":
-        {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"}, "ProcessorSummary":
-        {"Status": {"State": "Enabled", "Health": null, "HealthRollup": null}, "Count":
-        2, "Model": ""}, "SystemType": "Physical", "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
-        "PartNumber": "033RF3X04", "BiosVersion": "0.4.8", "EthernetInterfaces": {"@odata.id":
-        "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"}, "Description":
-        "Computer System which represents a machine (physical or virtual) and the
-        local resources such as memory, cpu and other devices that can be accessed
-        from that machine.", "Actions": {"#ComputerSystem.Reset": {"target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
-        "ResetType@Redfish.AllowableValues": ["On", "ForceOff", "GracefulRestart",
-        "GracefulShutdown", "PushPowerButton", "Nmi"]}}, "Boot": {"UefiTargetBootSourceOverride":
-        "", "BootSourceOverrideTarget": "None", "BootSourceOverrideTarget@Redfish.AllowableValues":
-        ["None", "Pxe", "Floppy", "Cd", "Hdd", "BiosSetup", "Utilities", "UefiTarget",
-        "SDCard", "UefiHttp"], "BootSourceOverrideEnabled": "Once", "BootSourceOverrideMode":
-        "UEFI"}, "Status": {"State": "StandbyOffline", "Health": "OK", "HealthRollup":
-        "OK"}}'
+      string: |-
+        {
+            "SimpleStorage": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"
+            },
+            "Links": {
+                "CooledBy@odata.count": 12,
+                "PoweredBy@odata.count": 0,
+                "Oem": {
+                    "Dell": {
+                        "BootSources": {
+                            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"
+                        },
+                        "@odata.type": "#Dell.v1_0_0.BootSources"
+                    }
+                },
+                "ManagedBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"
+                    }
+                ],
+                "Chassis": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1"
+                    }
+                ],
+                "Chassis@odata.count": 1,
+                "PoweredBy": [],
+                "CooledBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"
+                    }
+                ],
+                "ManagedBy@odata.count": 1
+            },
+            "Processors": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"
+            },
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "Manufacturer": "Dell Inc.",
+            "PowerState": "Off",
+            "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            "Name": "System",
+            "AssetTag": "",
+            "HostName": "",
+            "SerialNumber": "CN701636AB0013",
+            "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem",
+            "TrustedModules": [
+                {
+                    "Status": {
+                        "State": "Disabled"
+                    }
+                }
+            ],
+            "IndicatorLED": "Off",
+            "SKU": "",
+            "MemorySummary": {
+                "TotalSystemMemoryGiB": 32.0,
+                "Status": {
+                    "State": "Enabled",
+                    "Health": null,
+                    "HealthRollup": null
+                },
+                "MemoryMirroring": "System"
+            },
+            "Model": "DSS9630M",
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1",
+            "Id": "System.Embedded.1",
+            "Bios": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"
+            },
+            "SecureBoot": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"
+            },
+            "ProcessorSummary": {
+                "Status": {
+                    "State": "Enabled",
+                    "Health": null,
+                    "HealthRollup": null
+                },
+                "Count": 2,
+                "Model": ""
+            },
+            "SystemType": "Physical",
+            "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+            "PartNumber": "033RF3X04",
+            "BiosVersion": "0.4.8",
+            "EthernetInterfaces": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"
+            },
+            "Description": "Computer System which represents a machine (physical or virtual) and the local resources such as memory, cpu and other devices that can be accessed from that machine.",
+            "Actions": {
+                "#ComputerSystem.Reset": {
+                    "target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+                    "ResetType@Redfish.AllowableValues": [
+                        "On",
+                        "ForceOff",
+                        "GracefulRestart",
+                        "GracefulShutdown",
+                        "PushPowerButton",
+                        "Nmi"
+                    ]
+                }
+            },
+            "Boot": {
+                "UefiTargetBootSourceOverride": "",
+                "BootSourceOverrideTarget": "None",
+                "BootSourceOverrideTarget@Redfish.AllowableValues": [
+                    "None",
+                    "Pxe",
+                    "Floppy",
+                    "Cd",
+                    "Hdd",
+                    "BiosSetup",
+                    "Utilities",
+                    "UefiTarget",
+                    "SDCard",
+                    "UefiHttp"
+                ],
+                "BootSourceOverrideEnabled": "Once",
+                "BootSourceOverrideMode": "UEFI"
+            },
+            "Status": {
+                "State": "StandbyOffline",
+                "Health": "OK",
+                "HealthRollup": "OK"
+            }
+        }
     http_version: 
-  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:58 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset
@@ -171,21 +295,25 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - e190d3c5-6791-4dba-8ed8-f7fd306e239a
+      - dummy
       Content-Type:
       - application/json
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 501
+      message: 'Not Implemented '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Mon, 04 Jun 2018 10:23:19 GMT
+      - Wed, 13 Jun 2018 13:52:58 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:58 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_restart/restarts_the_system.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_restart/restarts_the_system.yml
@@ -16,33 +16,27 @@ http_interactions:
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
-      Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
-      Date:
-      - Mon, 04 Jun 2018 10:23:19 GMT
-      Odata-Version:
-      - '4.0'
       Content-Type:
       - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Wed, 13 Jun 2018 13:52:57 GMT
+      Content-Length:
+      - '1000'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context": "/redfish/v1/$metadata#ServiceRoot.ServiceRoot",
-        "@odata.id": "/redfish/v1", "@odata.type": "#ServiceRoot.v1_1_0.ServiceRoot",
-        "AccountService": {"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},
-        "Chassis": {"@odata.id": "/redfish/v1/Chassis"}, "Description": "Root Service",
-        "EventService": {"@odata.id": "/redfish/v1/EventService"}, "Id": "RootService",
-        "JsonSchemas": {"@odata.id": "/redfish/v1/JSONSchemas"}, "Links": {"Sessions":
-        {"@odata.id": "/redfish/v1/Sessions"}}, "Managers": {"@odata.id": "/redfish/v1/Managers"},
-        "Name": "Root Service", "Oem": {"Dell": {"@odata.type": "/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot",
-        "IsBranded": 0, "ManagerMACAddress": "10:98:36:a9:05:b0", "ServiceTag": ""}},
-        "RedfishVersion": "1.0.2", "Registries": {"@odata.id": "/redfish/v1/Registries"},
-        "SessionService": {"@odata.id": "/redfish/v1/SessionService"}, "Systems":
-        {"@odata.id": "/redfish/v1/Systems"}, "Tasks": {"@odata.id": "/redfish/v1/TaskService"},
-        "UpdateService": {"@odata.id": "/redfish/v1/UpdateService"}}'
+      string: '{"@odata.context":"/redfish/v1/$metadata#ServiceRoot.ServiceRoot","@odata.id":"/redfish/v1","@odata.type":"#ServiceRoot.v1_1_0.ServiceRoot","AccountService":{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},"Chassis":{"@odata.id":"/redfish/v1/Chassis"},"Description":"Root
+        Service","EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","JsonSchemas":{"@odata.id":"/redfish/v1/JSONSchemas"},"Links":{"Sessions":{"@odata.id":"/redfish/v1/Sessions"}},"Managers":{"@odata.id":"/redfish/v1/Managers"},"Name":"Root
+        Service","Oem":{"Dell":{"@odata.type":"/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot","IsBranded":0,"ManagerMACAddress":"10:98:36:a9:05:b0","ServiceTag":""}},"RedfishVersion":"1.0.2","Registries":{"@odata.id":"/redfish/v1/Registries"},"SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"Tasks":{"@odata.id":"/redfish/v1/TaskService"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}
+
+'
     http_version: 
-  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:57 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
@@ -61,28 +55,25 @@ http_interactions:
   response:
     status:
       code: 201
-      message: Created
+      message: 'Created '
     headers:
-      Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
-      Date:
-      - Mon, 04 Jun 2018 10:23:19 GMT
-      Odata-Version:
-      - '4.0'
       Content-Type:
       - application/json
-      Location:
-      - "/redfish/v1/Sessions/ad59416d-d962-4b5a-9d42-22b31d71d3dc"
       X-Auth-Token:
-      - 6196300e-364c-444e-9866-dd3adbd53eeb
+      - dummy
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Wed, 13 Jun 2018 13:52:57 GMT
+      Content-Length:
+      - '71'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context": "/redfish/v1/$metadata#Session.Session", "@odata.type":
-        "#Session.v1_0_0.Session", "Name": "User Session", "Description": "User Session",
-        "UserName": "REDFISH_USERID", "@odata.id": "/redfish/v1/Sessions/ad59416d-d962-4b5a-9d42-22b31d71d3dc",
-        "Id": "ad59416d-d962-4b5a-9d42-22b31d71d3dc"}'
+      string: '{"Name":"User Session","Description":"User Session","UserName":"REDFISH_USERID"}'
     http_version: 
-  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:57 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -97,66 +88,199 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 6196300e-364c-444e-9866-dd3adbd53eeb
+      - dummy
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - Apache/2.4
+      Cache-Control:
+      - no-cache
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Allow:
+      - POST,PATCH
+      Access-Control-Allow-Origin:
+      - "*"
       Date:
-      - Mon, 04 Jun 2018 10:23:19 GMT
+      - Sat, 20 May 2017 09:58:17 GMT
       Odata-Version:
       - '4.0'
-      Content-Type:
-      - application/json
+      Link:
+      - "</redfish/v1/Schemas/ComputerSystem.v1_1_0.json>;rel=describedby"
+      Content-Length:
+      - '5262'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"SimpleStorage": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},
-        "Links": {"CooledBy@odata.count": 12, "PoweredBy@odata.count": 0, "Oem": {"Dell":
-        {"BootSources": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"},
-        "@odata.type": "#Dell.v1_0_0.BootSources"}}, "ManagedBy": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}],
-        "Chassis": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1"}], "Chassis@odata.count":
-        1, "PoweredBy": [], "CooledBy": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],
-        "ManagedBy@odata.count": 1}, "Processors": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"},
-        "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
-        "Manufacturer": "Dell Inc.", "PowerState": "Off", "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
-        "Name": "System", "AssetTag": "", "HostName": "", "SerialNumber": "CN701636AB0013",
-        "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem", "TrustedModules":
-        [{"Status": {"State": "Disabled"}}], "IndicatorLED": "Off", "SKU": "", "MemorySummary":
-        {"TotalSystemMemoryGiB": 32.0, "Status": {"State": "Enabled", "Health": null,
-        "HealthRollup": null}, "MemoryMirroring": "System"}, "Model": "DSS9630M",
-        "@odata.id": "/redfish/v1/Systems/System.Embedded.1", "Id": "System.Embedded.1",
-        "Bios": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"}, "SecureBoot":
-        {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"}, "ProcessorSummary":
-        {"Status": {"State": "Enabled", "Health": null, "HealthRollup": null}, "Count":
-        2, "Model": ""}, "SystemType": "Physical", "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
-        "PartNumber": "033RF3X04", "BiosVersion": "0.4.8", "EthernetInterfaces": {"@odata.id":
-        "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"}, "Description":
-        "Computer System which represents a machine (physical or virtual) and the
-        local resources such as memory, cpu and other devices that can be accessed
-        from that machine.", "Actions": {"#ComputerSystem.Reset": {"target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
-        "ResetType@Redfish.AllowableValues": ["On", "ForceOff", "GracefulRestart",
-        "GracefulShutdown", "PushPowerButton", "Nmi"]}}, "Boot": {"UefiTargetBootSourceOverride":
-        "", "BootSourceOverrideTarget": "None", "BootSourceOverrideTarget@Redfish.AllowableValues":
-        ["None", "Pxe", "Floppy", "Cd", "Hdd", "BiosSetup", "Utilities", "UefiTarget",
-        "SDCard", "UefiHttp"], "BootSourceOverrideEnabled": "Once", "BootSourceOverrideMode":
-        "UEFI"}, "Status": {"State": "StandbyOffline", "Health": "OK", "HealthRollup":
-        "OK"}}'
+      string: |-
+        {
+            "SimpleStorage": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"
+            },
+            "Links": {
+                "CooledBy@odata.count": 12,
+                "PoweredBy@odata.count": 0,
+                "Oem": {
+                    "Dell": {
+                        "BootSources": {
+                            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"
+                        },
+                        "@odata.type": "#Dell.v1_0_0.BootSources"
+                    }
+                },
+                "ManagedBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"
+                    }
+                ],
+                "Chassis": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1"
+                    }
+                ],
+                "Chassis@odata.count": 1,
+                "PoweredBy": [],
+                "CooledBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"
+                    }
+                ],
+                "ManagedBy@odata.count": 1
+            },
+            "Processors": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"
+            },
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "Manufacturer": "Dell Inc.",
+            "PowerState": "Off",
+            "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            "Name": "System",
+            "AssetTag": "",
+            "HostName": "",
+            "SerialNumber": "CN701636AB0013",
+            "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem",
+            "TrustedModules": [
+                {
+                    "Status": {
+                        "State": "Disabled"
+                    }
+                }
+            ],
+            "IndicatorLED": "Off",
+            "SKU": "",
+            "MemorySummary": {
+                "TotalSystemMemoryGiB": 32.0,
+                "Status": {
+                    "State": "Enabled",
+                    "Health": null,
+                    "HealthRollup": null
+                },
+                "MemoryMirroring": "System"
+            },
+            "Model": "DSS9630M",
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1",
+            "Id": "System.Embedded.1",
+            "Bios": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"
+            },
+            "SecureBoot": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"
+            },
+            "ProcessorSummary": {
+                "Status": {
+                    "State": "Enabled",
+                    "Health": null,
+                    "HealthRollup": null
+                },
+                "Count": 2,
+                "Model": ""
+            },
+            "SystemType": "Physical",
+            "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+            "PartNumber": "033RF3X04",
+            "BiosVersion": "0.4.8",
+            "EthernetInterfaces": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"
+            },
+            "Description": "Computer System which represents a machine (physical or virtual) and the local resources such as memory, cpu and other devices that can be accessed from that machine.",
+            "Actions": {
+                "#ComputerSystem.Reset": {
+                    "target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+                    "ResetType@Redfish.AllowableValues": [
+                        "On",
+                        "ForceOff",
+                        "GracefulRestart",
+                        "GracefulShutdown",
+                        "PushPowerButton",
+                        "Nmi"
+                    ]
+                }
+            },
+            "Boot": {
+                "UefiTargetBootSourceOverride": "",
+                "BootSourceOverrideTarget": "None",
+                "BootSourceOverrideTarget@Redfish.AllowableValues": [
+                    "None",
+                    "Pxe",
+                    "Floppy",
+                    "Cd",
+                    "Hdd",
+                    "BiosSetup",
+                    "Utilities",
+                    "UefiTarget",
+                    "SDCard",
+                    "UefiHttp"
+                ],
+                "BootSourceOverrideEnabled": "Once",
+                "BootSourceOverrideMode": "UEFI"
+            },
+            "Status": {
+                "State": "StandbyOffline",
+                "Health": "OK",
+                "HealthRollup": "OK"
+            }
+        }
     http_version: 
-  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:57 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset
@@ -171,21 +295,25 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 6196300e-364c-444e-9866-dd3adbd53eeb
+      - dummy
       Content-Type:
       - application/json
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 501
+      message: 'Not Implemented '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Mon, 04 Jun 2018 10:23:19 GMT
+      - Wed, 13 Jun 2018 13:52:57 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:57 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_restart_now/restarts_the_system_immediately.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_restart_now/restarts_the_system_immediately.yml
@@ -16,33 +16,27 @@ http_interactions:
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
-      Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
-      Date:
-      - Mon, 04 Jun 2018 10:23:19 GMT
-      Odata-Version:
-      - '4.0'
       Content-Type:
       - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Wed, 13 Jun 2018 13:52:57 GMT
+      Content-Length:
+      - '1000'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context": "/redfish/v1/$metadata#ServiceRoot.ServiceRoot",
-        "@odata.id": "/redfish/v1", "@odata.type": "#ServiceRoot.v1_1_0.ServiceRoot",
-        "AccountService": {"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},
-        "Chassis": {"@odata.id": "/redfish/v1/Chassis"}, "Description": "Root Service",
-        "EventService": {"@odata.id": "/redfish/v1/EventService"}, "Id": "RootService",
-        "JsonSchemas": {"@odata.id": "/redfish/v1/JSONSchemas"}, "Links": {"Sessions":
-        {"@odata.id": "/redfish/v1/Sessions"}}, "Managers": {"@odata.id": "/redfish/v1/Managers"},
-        "Name": "Root Service", "Oem": {"Dell": {"@odata.type": "/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot",
-        "IsBranded": 0, "ManagerMACAddress": "10:98:36:a9:05:b0", "ServiceTag": ""}},
-        "RedfishVersion": "1.0.2", "Registries": {"@odata.id": "/redfish/v1/Registries"},
-        "SessionService": {"@odata.id": "/redfish/v1/SessionService"}, "Systems":
-        {"@odata.id": "/redfish/v1/Systems"}, "Tasks": {"@odata.id": "/redfish/v1/TaskService"},
-        "UpdateService": {"@odata.id": "/redfish/v1/UpdateService"}}'
+      string: '{"@odata.context":"/redfish/v1/$metadata#ServiceRoot.ServiceRoot","@odata.id":"/redfish/v1","@odata.type":"#ServiceRoot.v1_1_0.ServiceRoot","AccountService":{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},"Chassis":{"@odata.id":"/redfish/v1/Chassis"},"Description":"Root
+        Service","EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","JsonSchemas":{"@odata.id":"/redfish/v1/JSONSchemas"},"Links":{"Sessions":{"@odata.id":"/redfish/v1/Sessions"}},"Managers":{"@odata.id":"/redfish/v1/Managers"},"Name":"Root
+        Service","Oem":{"Dell":{"@odata.type":"/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot","IsBranded":0,"ManagerMACAddress":"10:98:36:a9:05:b0","ServiceTag":""}},"RedfishVersion":"1.0.2","Registries":{"@odata.id":"/redfish/v1/Registries"},"SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"Tasks":{"@odata.id":"/redfish/v1/TaskService"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}
+
+'
     http_version: 
-  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:57 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
@@ -61,28 +55,25 @@ http_interactions:
   response:
     status:
       code: 201
-      message: Created
+      message: 'Created '
     headers:
-      Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
-      Date:
-      - Mon, 04 Jun 2018 10:23:19 GMT
-      Odata-Version:
-      - '4.0'
       Content-Type:
       - application/json
-      Location:
-      - "/redfish/v1/Sessions/2a16495e-31ec-48eb-8c03-44c478f5efff"
       X-Auth-Token:
-      - a94f8c52-0ae2-49a3-baf0-7a2eba764c31
+      - dummy
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Wed, 13 Jun 2018 13:52:57 GMT
+      Content-Length:
+      - '71'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context": "/redfish/v1/$metadata#Session.Session", "@odata.type":
-        "#Session.v1_0_0.Session", "Name": "User Session", "Description": "User Session",
-        "UserName": "REDFISH_USERID", "@odata.id": "/redfish/v1/Sessions/2a16495e-31ec-48eb-8c03-44c478f5efff",
-        "Id": "2a16495e-31ec-48eb-8c03-44c478f5efff"}'
+      string: '{"Name":"User Session","Description":"User Session","UserName":"REDFISH_USERID"}'
     http_version: 
-  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:57 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -97,66 +88,199 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - a94f8c52-0ae2-49a3-baf0-7a2eba764c31
+      - dummy
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - Apache/2.4
+      Cache-Control:
+      - no-cache
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Allow:
+      - POST,PATCH
+      Access-Control-Allow-Origin:
+      - "*"
       Date:
-      - Mon, 04 Jun 2018 10:23:19 GMT
+      - Sat, 20 May 2017 09:58:17 GMT
       Odata-Version:
       - '4.0'
-      Content-Type:
-      - application/json
+      Link:
+      - "</redfish/v1/Schemas/ComputerSystem.v1_1_0.json>;rel=describedby"
+      Content-Length:
+      - '5262'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"SimpleStorage": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},
-        "Links": {"CooledBy@odata.count": 12, "PoweredBy@odata.count": 0, "Oem": {"Dell":
-        {"BootSources": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"},
-        "@odata.type": "#Dell.v1_0_0.BootSources"}}, "ManagedBy": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}],
-        "Chassis": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1"}], "Chassis@odata.count":
-        1, "PoweredBy": [], "CooledBy": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],
-        "ManagedBy@odata.count": 1}, "Processors": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"},
-        "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
-        "Manufacturer": "Dell Inc.", "PowerState": "Off", "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
-        "Name": "System", "AssetTag": "", "HostName": "", "SerialNumber": "CN701636AB0013",
-        "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem", "TrustedModules":
-        [{"Status": {"State": "Disabled"}}], "IndicatorLED": "Off", "SKU": "", "MemorySummary":
-        {"TotalSystemMemoryGiB": 32.0, "Status": {"State": "Enabled", "Health": null,
-        "HealthRollup": null}, "MemoryMirroring": "System"}, "Model": "DSS9630M",
-        "@odata.id": "/redfish/v1/Systems/System.Embedded.1", "Id": "System.Embedded.1",
-        "Bios": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"}, "SecureBoot":
-        {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"}, "ProcessorSummary":
-        {"Status": {"State": "Enabled", "Health": null, "HealthRollup": null}, "Count":
-        2, "Model": ""}, "SystemType": "Physical", "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
-        "PartNumber": "033RF3X04", "BiosVersion": "0.4.8", "EthernetInterfaces": {"@odata.id":
-        "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"}, "Description":
-        "Computer System which represents a machine (physical or virtual) and the
-        local resources such as memory, cpu and other devices that can be accessed
-        from that machine.", "Actions": {"#ComputerSystem.Reset": {"target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
-        "ResetType@Redfish.AllowableValues": ["On", "ForceOff", "GracefulRestart",
-        "GracefulShutdown", "PushPowerButton", "Nmi"]}}, "Boot": {"UefiTargetBootSourceOverride":
-        "", "BootSourceOverrideTarget": "None", "BootSourceOverrideTarget@Redfish.AllowableValues":
-        ["None", "Pxe", "Floppy", "Cd", "Hdd", "BiosSetup", "Utilities", "UefiTarget",
-        "SDCard", "UefiHttp"], "BootSourceOverrideEnabled": "Once", "BootSourceOverrideMode":
-        "UEFI"}, "Status": {"State": "StandbyOffline", "Health": "OK", "HealthRollup":
-        "OK"}}'
+      string: |-
+        {
+            "SimpleStorage": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"
+            },
+            "Links": {
+                "CooledBy@odata.count": 12,
+                "PoweredBy@odata.count": 0,
+                "Oem": {
+                    "Dell": {
+                        "BootSources": {
+                            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"
+                        },
+                        "@odata.type": "#Dell.v1_0_0.BootSources"
+                    }
+                },
+                "ManagedBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"
+                    }
+                ],
+                "Chassis": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1"
+                    }
+                ],
+                "Chassis@odata.count": 1,
+                "PoweredBy": [],
+                "CooledBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"
+                    }
+                ],
+                "ManagedBy@odata.count": 1
+            },
+            "Processors": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"
+            },
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "Manufacturer": "Dell Inc.",
+            "PowerState": "Off",
+            "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            "Name": "System",
+            "AssetTag": "",
+            "HostName": "",
+            "SerialNumber": "CN701636AB0013",
+            "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem",
+            "TrustedModules": [
+                {
+                    "Status": {
+                        "State": "Disabled"
+                    }
+                }
+            ],
+            "IndicatorLED": "Off",
+            "SKU": "",
+            "MemorySummary": {
+                "TotalSystemMemoryGiB": 32.0,
+                "Status": {
+                    "State": "Enabled",
+                    "Health": null,
+                    "HealthRollup": null
+                },
+                "MemoryMirroring": "System"
+            },
+            "Model": "DSS9630M",
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1",
+            "Id": "System.Embedded.1",
+            "Bios": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"
+            },
+            "SecureBoot": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"
+            },
+            "ProcessorSummary": {
+                "Status": {
+                    "State": "Enabled",
+                    "Health": null,
+                    "HealthRollup": null
+                },
+                "Count": 2,
+                "Model": ""
+            },
+            "SystemType": "Physical",
+            "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+            "PartNumber": "033RF3X04",
+            "BiosVersion": "0.4.8",
+            "EthernetInterfaces": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"
+            },
+            "Description": "Computer System which represents a machine (physical or virtual) and the local resources such as memory, cpu and other devices that can be accessed from that machine.",
+            "Actions": {
+                "#ComputerSystem.Reset": {
+                    "target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+                    "ResetType@Redfish.AllowableValues": [
+                        "On",
+                        "ForceOff",
+                        "GracefulRestart",
+                        "GracefulShutdown",
+                        "PushPowerButton",
+                        "Nmi"
+                    ]
+                }
+            },
+            "Boot": {
+                "UefiTargetBootSourceOverride": "",
+                "BootSourceOverrideTarget": "None",
+                "BootSourceOverrideTarget@Redfish.AllowableValues": [
+                    "None",
+                    "Pxe",
+                    "Floppy",
+                    "Cd",
+                    "Hdd",
+                    "BiosSetup",
+                    "Utilities",
+                    "UefiTarget",
+                    "SDCard",
+                    "UefiHttp"
+                ],
+                "BootSourceOverrideEnabled": "Once",
+                "BootSourceOverrideMode": "UEFI"
+            },
+            "Status": {
+                "State": "StandbyOffline",
+                "Health": "OK",
+                "HealthRollup": "OK"
+            }
+        }
     http_version: 
-  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:57 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset
@@ -171,21 +295,25 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - a94f8c52-0ae2-49a3-baf0-7a2eba764c31
+      - dummy
       Content-Type:
       - application/json
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 501
+      message: 'Not Implemented '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Mon, 04 Jun 2018 10:23:19 GMT
+      - Wed, 13 Jun 2018 13:52:57 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Mon, 04 Jun 2018 10:23:19 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:57 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_turn_off_loc_led/turns_off_location_LED.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_turn_off_loc_led/turns_off_location_LED.yml
@@ -16,33 +16,27 @@ http_interactions:
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
-      Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
-      Date:
-      - Fri, 08 Jun 2018 08:27:26 GMT
-      Odata-Version:
-      - '4.0'
       Content-Type:
       - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Wed, 13 Jun 2018 13:52:59 GMT
+      Content-Length:
+      - '1000'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context": "/redfish/v1/$metadata#ServiceRoot.ServiceRoot",
-        "@odata.id": "/redfish/v1", "@odata.type": "#ServiceRoot.v1_1_0.ServiceRoot",
-        "AccountService": {"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},
-        "Chassis": {"@odata.id": "/redfish/v1/Chassis"}, "Description": "Root Service",
-        "EventService": {"@odata.id": "/redfish/v1/EventService"}, "Id": "RootService",
-        "JsonSchemas": {"@odata.id": "/redfish/v1/JSONSchemas"}, "Links": {"Sessions":
-        {"@odata.id": "/redfish/v1/Sessions"}}, "Managers": {"@odata.id": "/redfish/v1/Managers"},
-        "Name": "Root Service", "Oem": {"Dell": {"@odata.type": "/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot",
-        "IsBranded": 0, "ManagerMACAddress": "10:98:36:a9:05:b0", "ServiceTag": ""}},
-        "RedfishVersion": "1.0.2", "Registries": {"@odata.id": "/redfish/v1/Registries"},
-        "SessionService": {"@odata.id": "/redfish/v1/SessionService"}, "Systems":
-        {"@odata.id": "/redfish/v1/Systems"}, "Tasks": {"@odata.id": "/redfish/v1/TaskService"},
-        "UpdateService": {"@odata.id": "/redfish/v1/UpdateService"}}'
+      string: '{"@odata.context":"/redfish/v1/$metadata#ServiceRoot.ServiceRoot","@odata.id":"/redfish/v1","@odata.type":"#ServiceRoot.v1_1_0.ServiceRoot","AccountService":{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},"Chassis":{"@odata.id":"/redfish/v1/Chassis"},"Description":"Root
+        Service","EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","JsonSchemas":{"@odata.id":"/redfish/v1/JSONSchemas"},"Links":{"Sessions":{"@odata.id":"/redfish/v1/Sessions"}},"Managers":{"@odata.id":"/redfish/v1/Managers"},"Name":"Root
+        Service","Oem":{"Dell":{"@odata.type":"/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot","IsBranded":0,"ManagerMACAddress":"10:98:36:a9:05:b0","ServiceTag":""}},"RedfishVersion":"1.0.2","Registries":{"@odata.id":"/redfish/v1/Registries"},"SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"Tasks":{"@odata.id":"/redfish/v1/TaskService"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}
+
+'
     http_version: 
-  recorded_at: Fri, 08 Jun 2018 08:27:26 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
@@ -61,28 +55,25 @@ http_interactions:
   response:
     status:
       code: 201
-      message: Created
+      message: 'Created '
     headers:
-      Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
-      Date:
-      - Fri, 08 Jun 2018 08:27:26 GMT
-      Odata-Version:
-      - '4.0'
       Content-Type:
       - application/json
-      Location:
-      - "/redfish/v1/Sessions/c8bcb113-c00e-42a2-8dfb-52ccf0b91658"
       X-Auth-Token:
-      - 2ae15c56-f0eb-469d-bc8a-7a3322035880
+      - dummy
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Wed, 13 Jun 2018 13:52:59 GMT
+      Content-Length:
+      - '71'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context": "/redfish/v1/$metadata#Session.Session", "@odata.type":
-        "#Session.v1_0_0.Session", "Name": "User Session", "Description": "User Session",
-        "UserName": "REDFISH_USERID", "@odata.id": "/redfish/v1/Sessions/c8bcb113-c00e-42a2-8dfb-52ccf0b91658",
-        "Id": "c8bcb113-c00e-42a2-8dfb-52ccf0b91658"}'
+      string: '{"Name":"User Session","Description":"User Session","UserName":"REDFISH_USERID"}'
     http_version: 
-  recorded_at: Fri, 08 Jun 2018 08:27:26 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -97,66 +88,199 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 2ae15c56-f0eb-469d-bc8a-7a3322035880
+      - dummy
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - Apache/2.4
+      Cache-Control:
+      - no-cache
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Allow:
+      - POST,PATCH
+      Access-Control-Allow-Origin:
+      - "*"
       Date:
-      - Fri, 08 Jun 2018 08:27:26 GMT
+      - Sat, 20 May 2017 09:58:17 GMT
       Odata-Version:
       - '4.0'
-      Content-Type:
-      - application/json
+      Link:
+      - "</redfish/v1/Schemas/ComputerSystem.v1_1_0.json>;rel=describedby"
+      Content-Length:
+      - '5262'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"SimpleStorage": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},
-        "Links": {"CooledBy@odata.count": 12, "PoweredBy@odata.count": 0, "Oem": {"Dell":
-        {"BootSources": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"},
-        "@odata.type": "#Dell.v1_0_0.BootSources"}}, "ManagedBy": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}],
-        "Chassis": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1"}], "Chassis@odata.count":
-        1, "PoweredBy": [], "CooledBy": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],
-        "ManagedBy@odata.count": 1}, "Processors": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"},
-        "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
-        "Manufacturer": "Dell Inc.", "PowerState": "Off", "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
-        "Name": "System", "AssetTag": "", "HostName": "", "SerialNumber": "CN701636AB0013",
-        "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem", "TrustedModules":
-        [{"Status": {"State": "Disabled"}}], "IndicatorLED": "Off", "SKU": "", "MemorySummary":
-        {"TotalSystemMemoryGiB": 32.0, "Status": {"State": "Enabled", "Health": null,
-        "HealthRollup": null}, "MemoryMirroring": "System"}, "Model": "DSS9630M",
-        "@odata.id": "/redfish/v1/Systems/System.Embedded.1", "Id": "System.Embedded.1",
-        "Bios": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"}, "SecureBoot":
-        {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"}, "ProcessorSummary":
-        {"Status": {"State": "Enabled", "Health": null, "HealthRollup": null}, "Count":
-        2, "Model": ""}, "SystemType": "Physical", "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
-        "PartNumber": "033RF3X04", "BiosVersion": "0.4.8", "EthernetInterfaces": {"@odata.id":
-        "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"}, "Description":
-        "Computer System which represents a machine (physical or virtual) and the
-        local resources such as memory, cpu and other devices that can be accessed
-        from that machine.", "Actions": {"#ComputerSystem.Reset": {"target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
-        "ResetType@Redfish.AllowableValues": ["On", "ForceOff", "GracefulRestart",
-        "GracefulShutdown", "PushPowerButton", "Nmi"]}}, "Boot": {"UefiTargetBootSourceOverride":
-        "", "BootSourceOverrideTarget": "None", "BootSourceOverrideTarget@Redfish.AllowableValues":
-        ["None", "Pxe", "Floppy", "Cd", "Hdd", "BiosSetup", "Utilities", "UefiTarget",
-        "SDCard", "UefiHttp"], "BootSourceOverrideEnabled": "Once", "BootSourceOverrideMode":
-        "UEFI"}, "Status": {"State": "StandbyOffline", "Health": "OK", "HealthRollup":
-        "OK"}}'
+      string: |-
+        {
+            "SimpleStorage": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"
+            },
+            "Links": {
+                "CooledBy@odata.count": 12,
+                "PoweredBy@odata.count": 0,
+                "Oem": {
+                    "Dell": {
+                        "BootSources": {
+                            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"
+                        },
+                        "@odata.type": "#Dell.v1_0_0.BootSources"
+                    }
+                },
+                "ManagedBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"
+                    }
+                ],
+                "Chassis": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1"
+                    }
+                ],
+                "Chassis@odata.count": 1,
+                "PoweredBy": [],
+                "CooledBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"
+                    }
+                ],
+                "ManagedBy@odata.count": 1
+            },
+            "Processors": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"
+            },
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "Manufacturer": "Dell Inc.",
+            "PowerState": "Off",
+            "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            "Name": "System",
+            "AssetTag": "",
+            "HostName": "",
+            "SerialNumber": "CN701636AB0013",
+            "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem",
+            "TrustedModules": [
+                {
+                    "Status": {
+                        "State": "Disabled"
+                    }
+                }
+            ],
+            "IndicatorLED": "Off",
+            "SKU": "",
+            "MemorySummary": {
+                "TotalSystemMemoryGiB": 32.0,
+                "Status": {
+                    "State": "Enabled",
+                    "Health": null,
+                    "HealthRollup": null
+                },
+                "MemoryMirroring": "System"
+            },
+            "Model": "DSS9630M",
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1",
+            "Id": "System.Embedded.1",
+            "Bios": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"
+            },
+            "SecureBoot": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"
+            },
+            "ProcessorSummary": {
+                "Status": {
+                    "State": "Enabled",
+                    "Health": null,
+                    "HealthRollup": null
+                },
+                "Count": 2,
+                "Model": ""
+            },
+            "SystemType": "Physical",
+            "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+            "PartNumber": "033RF3X04",
+            "BiosVersion": "0.4.8",
+            "EthernetInterfaces": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"
+            },
+            "Description": "Computer System which represents a machine (physical or virtual) and the local resources such as memory, cpu and other devices that can be accessed from that machine.",
+            "Actions": {
+                "#ComputerSystem.Reset": {
+                    "target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+                    "ResetType@Redfish.AllowableValues": [
+                        "On",
+                        "ForceOff",
+                        "GracefulRestart",
+                        "GracefulShutdown",
+                        "PushPowerButton",
+                        "Nmi"
+                    ]
+                }
+            },
+            "Boot": {
+                "UefiTargetBootSourceOverride": "",
+                "BootSourceOverrideTarget": "None",
+                "BootSourceOverrideTarget@Redfish.AllowableValues": [
+                    "None",
+                    "Pxe",
+                    "Floppy",
+                    "Cd",
+                    "Hdd",
+                    "BiosSetup",
+                    "Utilities",
+                    "UefiTarget",
+                    "SDCard",
+                    "UefiHttp"
+                ],
+                "BootSourceOverrideEnabled": "Once",
+                "BootSourceOverrideMode": "UEFI"
+            },
+            "Status": {
+                "State": "StandbyOffline",
+                "Health": "OK",
+                "HealthRollup": "OK"
+            }
+        }
     http_version: 
-  recorded_at: Fri, 08 Jun 2018 08:27:26 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
 - request:
     method: patch
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -171,66 +295,25 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 2ae15c56-f0eb-469d-bc8a-7a3322035880
+      - dummy
       Content-Type:
       - application/json
   response:
     status:
-      code: 200
-      message: OK
+      code: 501
+      message: 'Not Implemented '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Fri, 08 Jun 2018 08:27:26 GMT
-      Odata-Version:
-      - '4.0'
-      Content-Type:
-      - application/json
+      - Wed, 13 Jun 2018 13:52:59 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"SimpleStorage": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},
-        "Links": {"CooledBy@odata.count": 12, "PoweredBy@odata.count": 0, "Oem": {"Dell":
-        {"BootSources": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"},
-        "@odata.type": "#Dell.v1_0_0.BootSources"}}, "ManagedBy": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}],
-        "Chassis": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1"}], "Chassis@odata.count":
-        1, "PoweredBy": [], "CooledBy": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],
-        "ManagedBy@odata.count": 1}, "Processors": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"},
-        "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
-        "Manufacturer": "Dell Inc.", "PowerState": "Off", "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
-        "Name": "System", "AssetTag": "", "HostName": "", "SerialNumber": "CN701636AB0013",
-        "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem", "TrustedModules":
-        [{"Status": {"State": "Disabled"}}], "IndicatorLED": "Off", "SKU": "", "MemorySummary":
-        {"TotalSystemMemoryGiB": 32.0, "Status": {"State": "Enabled", "Health": null,
-        "HealthRollup": null}, "MemoryMirroring": "System"}, "Model": "DSS9630M",
-        "@odata.id": "/redfish/v1/Systems/System.Embedded.1", "Id": "System.Embedded.1",
-        "Bios": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"}, "SecureBoot":
-        {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"}, "ProcessorSummary":
-        {"Status": {"State": "Enabled", "Health": null, "HealthRollup": null}, "Count":
-        2, "Model": ""}, "SystemType": "Physical", "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
-        "PartNumber": "033RF3X04", "BiosVersion": "0.4.8", "EthernetInterfaces": {"@odata.id":
-        "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"}, "Description":
-        "Computer System which represents a machine (physical or virtual) and the
-        local resources such as memory, cpu and other devices that can be accessed
-        from that machine.", "Actions": {"#ComputerSystem.Reset": {"target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
-        "ResetType@Redfish.AllowableValues": ["On", "ForceOff", "GracefulRestart",
-        "GracefulShutdown", "PushPowerButton", "Nmi"]}}, "Boot": {"UefiTargetBootSourceOverride":
-        "", "BootSourceOverrideTarget": "None", "BootSourceOverrideTarget@Redfish.AllowableValues":
-        ["None", "Pxe", "Floppy", "Cd", "Hdd", "BiosSetup", "Utilities", "UefiTarget",
-        "SDCard", "UefiHttp"], "BootSourceOverrideEnabled": "Once", "BootSourceOverrideMode":
-        "UEFI"}, "Status": {"State": "StandbyOffline", "Health": "OK", "HealthRollup":
-        "OK"}}'
+      string: ''
     http_version: 
-  recorded_at: Fri, 08 Jun 2018 08:27:26 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_turn_on_loc_led/turns_on_location_LED.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_turn_on_loc_led/turns_on_location_LED.yml
@@ -16,33 +16,27 @@ http_interactions:
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
-      Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
-      Date:
-      - Fri, 08 Jun 2018 08:27:27 GMT
-      Odata-Version:
-      - '4.0'
       Content-Type:
       - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Wed, 13 Jun 2018 13:52:59 GMT
+      Content-Length:
+      - '1000'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context": "/redfish/v1/$metadata#ServiceRoot.ServiceRoot",
-        "@odata.id": "/redfish/v1", "@odata.type": "#ServiceRoot.v1_1_0.ServiceRoot",
-        "AccountService": {"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},
-        "Chassis": {"@odata.id": "/redfish/v1/Chassis"}, "Description": "Root Service",
-        "EventService": {"@odata.id": "/redfish/v1/EventService"}, "Id": "RootService",
-        "JsonSchemas": {"@odata.id": "/redfish/v1/JSONSchemas"}, "Links": {"Sessions":
-        {"@odata.id": "/redfish/v1/Sessions"}}, "Managers": {"@odata.id": "/redfish/v1/Managers"},
-        "Name": "Root Service", "Oem": {"Dell": {"@odata.type": "/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot",
-        "IsBranded": 0, "ManagerMACAddress": "10:98:36:a9:05:b0", "ServiceTag": ""}},
-        "RedfishVersion": "1.0.2", "Registries": {"@odata.id": "/redfish/v1/Registries"},
-        "SessionService": {"@odata.id": "/redfish/v1/SessionService"}, "Systems":
-        {"@odata.id": "/redfish/v1/Systems"}, "Tasks": {"@odata.id": "/redfish/v1/TaskService"},
-        "UpdateService": {"@odata.id": "/redfish/v1/UpdateService"}}'
+      string: '{"@odata.context":"/redfish/v1/$metadata#ServiceRoot.ServiceRoot","@odata.id":"/redfish/v1","@odata.type":"#ServiceRoot.v1_1_0.ServiceRoot","AccountService":{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},"Chassis":{"@odata.id":"/redfish/v1/Chassis"},"Description":"Root
+        Service","EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","JsonSchemas":{"@odata.id":"/redfish/v1/JSONSchemas"},"Links":{"Sessions":{"@odata.id":"/redfish/v1/Sessions"}},"Managers":{"@odata.id":"/redfish/v1/Managers"},"Name":"Root
+        Service","Oem":{"Dell":{"@odata.type":"/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot","IsBranded":0,"ManagerMACAddress":"10:98:36:a9:05:b0","ServiceTag":""}},"RedfishVersion":"1.0.2","Registries":{"@odata.id":"/redfish/v1/Registries"},"SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"Tasks":{"@odata.id":"/redfish/v1/TaskService"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}
+
+'
     http_version: 
-  recorded_at: Fri, 08 Jun 2018 08:27:27 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
@@ -61,28 +55,25 @@ http_interactions:
   response:
     status:
       code: 201
-      message: Created
+      message: 'Created '
     headers:
-      Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
-      Date:
-      - Fri, 08 Jun 2018 08:27:27 GMT
-      Odata-Version:
-      - '4.0'
       Content-Type:
       - application/json
-      Location:
-      - "/redfish/v1/Sessions/6cff389e-b9d7-4ac2-92eb-ce08a079436c"
       X-Auth-Token:
-      - cef738b3-37c1-4608-aaa6-15ee2ea68834
+      - dummy
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Wed, 13 Jun 2018 13:52:59 GMT
+      Content-Length:
+      - '71'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context": "/redfish/v1/$metadata#Session.Session", "@odata.type":
-        "#Session.v1_0_0.Session", "Name": "User Session", "Description": "User Session",
-        "UserName": "REDFISH_USERID", "@odata.id": "/redfish/v1/Sessions/6cff389e-b9d7-4ac2-92eb-ce08a079436c",
-        "Id": "6cff389e-b9d7-4ac2-92eb-ce08a079436c"}'
+      string: '{"Name":"User Session","Description":"User Session","UserName":"REDFISH_USERID"}'
     http_version: 
-  recorded_at: Fri, 08 Jun 2018 08:27:27 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -97,66 +88,199 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - cef738b3-37c1-4608-aaa6-15ee2ea68834
+      - dummy
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - Apache/2.4
+      Cache-Control:
+      - no-cache
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Allow:
+      - POST,PATCH
+      Access-Control-Allow-Origin:
+      - "*"
       Date:
-      - Fri, 08 Jun 2018 08:27:27 GMT
+      - Sat, 20 May 2017 09:58:17 GMT
       Odata-Version:
       - '4.0'
-      Content-Type:
-      - application/json
+      Link:
+      - "</redfish/v1/Schemas/ComputerSystem.v1_1_0.json>;rel=describedby"
+      Content-Length:
+      - '5262'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"SimpleStorage": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},
-        "Links": {"CooledBy@odata.count": 12, "PoweredBy@odata.count": 0, "Oem": {"Dell":
-        {"BootSources": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"},
-        "@odata.type": "#Dell.v1_0_0.BootSources"}}, "ManagedBy": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}],
-        "Chassis": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1"}], "Chassis@odata.count":
-        1, "PoweredBy": [], "CooledBy": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],
-        "ManagedBy@odata.count": 1}, "Processors": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"},
-        "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
-        "Manufacturer": "Dell Inc.", "PowerState": "Off", "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
-        "Name": "System", "AssetTag": "", "HostName": "", "SerialNumber": "CN701636AB0013",
-        "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem", "TrustedModules":
-        [{"Status": {"State": "Disabled"}}], "IndicatorLED": "Off", "SKU": "", "MemorySummary":
-        {"TotalSystemMemoryGiB": 32.0, "Status": {"State": "Enabled", "Health": null,
-        "HealthRollup": null}, "MemoryMirroring": "System"}, "Model": "DSS9630M",
-        "@odata.id": "/redfish/v1/Systems/System.Embedded.1", "Id": "System.Embedded.1",
-        "Bios": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"}, "SecureBoot":
-        {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"}, "ProcessorSummary":
-        {"Status": {"State": "Enabled", "Health": null, "HealthRollup": null}, "Count":
-        2, "Model": ""}, "SystemType": "Physical", "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
-        "PartNumber": "033RF3X04", "BiosVersion": "0.4.8", "EthernetInterfaces": {"@odata.id":
-        "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"}, "Description":
-        "Computer System which represents a machine (physical or virtual) and the
-        local resources such as memory, cpu and other devices that can be accessed
-        from that machine.", "Actions": {"#ComputerSystem.Reset": {"target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
-        "ResetType@Redfish.AllowableValues": ["On", "ForceOff", "GracefulRestart",
-        "GracefulShutdown", "PushPowerButton", "Nmi"]}}, "Boot": {"UefiTargetBootSourceOverride":
-        "", "BootSourceOverrideTarget": "None", "BootSourceOverrideTarget@Redfish.AllowableValues":
-        ["None", "Pxe", "Floppy", "Cd", "Hdd", "BiosSetup", "Utilities", "UefiTarget",
-        "SDCard", "UefiHttp"], "BootSourceOverrideEnabled": "Once", "BootSourceOverrideMode":
-        "UEFI"}, "Status": {"State": "StandbyOffline", "Health": "OK", "HealthRollup":
-        "OK"}}'
+      string: |-
+        {
+            "SimpleStorage": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"
+            },
+            "Links": {
+                "CooledBy@odata.count": 12,
+                "PoweredBy@odata.count": 0,
+                "Oem": {
+                    "Dell": {
+                        "BootSources": {
+                            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"
+                        },
+                        "@odata.type": "#Dell.v1_0_0.BootSources"
+                    }
+                },
+                "ManagedBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"
+                    }
+                ],
+                "Chassis": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1"
+                    }
+                ],
+                "Chassis@odata.count": 1,
+                "PoweredBy": [],
+                "CooledBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"
+                    }
+                ],
+                "ManagedBy@odata.count": 1
+            },
+            "Processors": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"
+            },
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "Manufacturer": "Dell Inc.",
+            "PowerState": "Off",
+            "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            "Name": "System",
+            "AssetTag": "",
+            "HostName": "",
+            "SerialNumber": "CN701636AB0013",
+            "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem",
+            "TrustedModules": [
+                {
+                    "Status": {
+                        "State": "Disabled"
+                    }
+                }
+            ],
+            "IndicatorLED": "Off",
+            "SKU": "",
+            "MemorySummary": {
+                "TotalSystemMemoryGiB": 32.0,
+                "Status": {
+                    "State": "Enabled",
+                    "Health": null,
+                    "HealthRollup": null
+                },
+                "MemoryMirroring": "System"
+            },
+            "Model": "DSS9630M",
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1",
+            "Id": "System.Embedded.1",
+            "Bios": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"
+            },
+            "SecureBoot": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"
+            },
+            "ProcessorSummary": {
+                "Status": {
+                    "State": "Enabled",
+                    "Health": null,
+                    "HealthRollup": null
+                },
+                "Count": 2,
+                "Model": ""
+            },
+            "SystemType": "Physical",
+            "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+            "PartNumber": "033RF3X04",
+            "BiosVersion": "0.4.8",
+            "EthernetInterfaces": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"
+            },
+            "Description": "Computer System which represents a machine (physical or virtual) and the local resources such as memory, cpu and other devices that can be accessed from that machine.",
+            "Actions": {
+                "#ComputerSystem.Reset": {
+                    "target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+                    "ResetType@Redfish.AllowableValues": [
+                        "On",
+                        "ForceOff",
+                        "GracefulRestart",
+                        "GracefulShutdown",
+                        "PushPowerButton",
+                        "Nmi"
+                    ]
+                }
+            },
+            "Boot": {
+                "UefiTargetBootSourceOverride": "",
+                "BootSourceOverrideTarget": "None",
+                "BootSourceOverrideTarget@Redfish.AllowableValues": [
+                    "None",
+                    "Pxe",
+                    "Floppy",
+                    "Cd",
+                    "Hdd",
+                    "BiosSetup",
+                    "Utilities",
+                    "UefiTarget",
+                    "SDCard",
+                    "UefiHttp"
+                ],
+                "BootSourceOverrideEnabled": "Once",
+                "BootSourceOverrideMode": "UEFI"
+            },
+            "Status": {
+                "State": "StandbyOffline",
+                "Health": "OK",
+                "HealthRollup": "OK"
+            }
+        }
     http_version: 
-  recorded_at: Fri, 08 Jun 2018 08:27:27 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
 - request:
     method: patch
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -171,66 +295,25 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - cef738b3-37c1-4608-aaa6-15ee2ea68834
+      - dummy
       Content-Type:
       - application/json
   response:
     status:
-      code: 200
-      message: OK
+      code: 501
+      message: 'Not Implemented '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Fri, 08 Jun 2018 08:27:27 GMT
-      Odata-Version:
-      - '4.0'
-      Content-Type:
-      - application/json
+      - Wed, 13 Jun 2018 13:52:59 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"SimpleStorage": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},
-        "Links": {"CooledBy@odata.count": 12, "PoweredBy@odata.count": 0, "Oem": {"Dell":
-        {"BootSources": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"},
-        "@odata.type": "#Dell.v1_0_0.BootSources"}}, "ManagedBy": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}],
-        "Chassis": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1"}], "Chassis@odata.count":
-        1, "PoweredBy": [], "CooledBy": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],
-        "ManagedBy@odata.count": 1}, "Processors": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"},
-        "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
-        "Manufacturer": "Dell Inc.", "PowerState": "Off", "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
-        "Name": "System", "AssetTag": "", "HostName": "", "SerialNumber": "CN701636AB0013",
-        "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem", "TrustedModules":
-        [{"Status": {"State": "Disabled"}}], "IndicatorLED": "Lit", "SKU": "", "MemorySummary":
-        {"TotalSystemMemoryGiB": 32.0, "Status": {"State": "Enabled", "Health": null,
-        "HealthRollup": null}, "MemoryMirroring": "System"}, "Model": "DSS9630M",
-        "@odata.id": "/redfish/v1/Systems/System.Embedded.1", "Id": "System.Embedded.1",
-        "Bios": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"}, "SecureBoot":
-        {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"}, "ProcessorSummary":
-        {"Status": {"State": "Enabled", "Health": null, "HealthRollup": null}, "Count":
-        2, "Model": ""}, "SystemType": "Physical", "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
-        "PartNumber": "033RF3X04", "BiosVersion": "0.4.8", "EthernetInterfaces": {"@odata.id":
-        "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"}, "Description":
-        "Computer System which represents a machine (physical or virtual) and the
-        local resources such as memory, cpu and other devices that can be accessed
-        from that machine.", "Actions": {"#ComputerSystem.Reset": {"target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
-        "ResetType@Redfish.AllowableValues": ["On", "ForceOff", "GracefulRestart",
-        "GracefulShutdown", "PushPowerButton", "Nmi"]}}, "Boot": {"UefiTargetBootSourceOverride":
-        "", "BootSourceOverrideTarget": "None", "BootSourceOverrideTarget@Redfish.AllowableValues":
-        ["None", "Pxe", "Floppy", "Cd", "Hdd", "BiosSetup", "Utilities", "UefiTarget",
-        "SDCard", "UefiHttp"], "BootSourceOverrideEnabled": "Once", "BootSourceOverrideMode":
-        "UEFI"}, "Status": {"State": "StandbyOffline", "Health": "OK", "HealthRollup":
-        "OK"}}'
+      string: ''
     http_version: 
-  recorded_at: Fri, 08 Jun 2018 08:27:27 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager_Refresher/refresh/will_perform_a_full_refresh.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager_Refresher/refresh/will_perform_a_full_refresh.yml
@@ -7,6 +7,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      User-Agent:
+      - excon/0.62.0
       Accept:
       - application/json
       Odata-Version:
@@ -14,33 +16,27 @@ http_interactions:
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
-      Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
-      Date:
-      - Mon, 28 May 2018 07:15:35 GMT
-      Odata-Version:
-      - '4.0'
       Content-Type:
       - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Wed, 13 Jun 2018 13:52:58 GMT
+      Content-Length:
+      - '1000'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context": "/redfish/v1/$metadata#ServiceRoot.ServiceRoot",
-        "@odata.id": "/redfish/v1", "@odata.type": "#ServiceRoot.v1_1_0.ServiceRoot",
-        "AccountService": {"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},
-        "Chassis": {"@odata.id": "/redfish/v1/Chassis"}, "Description": "Root Service",
-        "EventService": {"@odata.id": "/redfish/v1/EventService"}, "Id": "RootService",
-        "JsonSchemas": {"@odata.id": "/redfish/v1/JSONSchemas"}, "Links": {"Sessions":
-        {"@odata.id": "/redfish/v1/Sessions"}}, "Managers": {"@odata.id": "/redfish/v1/Managers"},
-        "Name": "Root Service", "Oem": {"Dell": {"@odata.type": "/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot",
-        "IsBranded": 0, "ManagerMACAddress": "10:98:36:a9:05:b0", "ServiceTag": ""}},
-        "RedfishVersion": "1.0.2", "Registries": {"@odata.id": "/redfish/v1/Registries"},
-        "SessionService": {"@odata.id": "/redfish/v1/SessionService"}, "Systems":
-        {"@odata.id": "/redfish/v1/Systems"}, "Tasks": {"@odata.id": "/redfish/v1/TaskService"},
-        "UpdateService": {"@odata.id": "/redfish/v1/UpdateService"}}'
+      string: '{"@odata.context":"/redfish/v1/$metadata#ServiceRoot.ServiceRoot","@odata.id":"/redfish/v1","@odata.type":"#ServiceRoot.v1_1_0.ServiceRoot","AccountService":{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},"Chassis":{"@odata.id":"/redfish/v1/Chassis"},"Description":"Root
+        Service","EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","JsonSchemas":{"@odata.id":"/redfish/v1/JSONSchemas"},"Links":{"Sessions":{"@odata.id":"/redfish/v1/Sessions"}},"Managers":{"@odata.id":"/redfish/v1/Managers"},"Name":"Root
+        Service","Oem":{"Dell":{"@odata.type":"/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot","IsBranded":0,"ManagerMACAddress":"10:98:36:a9:05:b0","ServiceTag":""}},"RedfishVersion":"1.0.2","Registries":{"@odata.id":"/redfish/v1/Registries"},"SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"Tasks":{"@odata.id":"/redfish/v1/TaskService"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}
+
+'
     http_version: 
-  recorded_at: Mon, 28 May 2018 07:15:35 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:58 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
@@ -48,35 +44,36 @@ http_interactions:
       encoding: UTF-8
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
     headers:
+      User-Agent:
+      - excon/0.62.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
+      Content-Type:
+      - application/json
   response:
     status:
       code: 201
-      message: Created
+      message: 'Created '
     headers:
-      Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
-      Date:
-      - Mon, 28 May 2018 07:15:35 GMT
-      Odata-Version:
-      - '4.0'
       Content-Type:
       - application/json
-      Location:
-      - "/redfish/v1/Sessions/5be09ff4-a454-4a43-b5f8-f47dc82a2659"
       X-Auth-Token:
-      - a17159f6-f554-478f-afcb-73cba94b242e
+      - dummy
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Wed, 13 Jun 2018 13:52:58 GMT
+      Content-Length:
+      - '71'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context": "/redfish/v1/$metadata#Session.Session", "@odata.type":
-        "#Session.v1_0_0.Session", "Name": "User Session", "Description": "User Session",
-        "UserName": "REDFISH_USERID", "@odata.id": "/redfish/v1/Sessions/5be09ff4-a454-4a43-b5f8-f47dc82a2659",
-        "Id": "5be09ff4-a454-4a43-b5f8-f47dc82a2659"}'
+      string: '{"Name":"User Session","Description":"User Session","UserName":"REDFISH_USERID"}'
     http_version: 
-  recorded_at: Mon, 28 May 2018 07:15:35 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:58 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems
@@ -84,34 +81,58 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      User-Agent:
+      - excon/0.62.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - a17159f6-f554-478f-afcb-73cba94b242e
+      - dummy
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - Apache/2.4
       Date:
-      - Mon, 28 May 2018 07:15:35 GMT
+      - Sat, 20 May 2017 09:58:16 GMT
       Odata-Version:
       - '4.0'
+      X-Frame-Options:
+      - DENY
       Content-Type:
-      - application/json
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Link:
+      - "</redfish/v1/Schemas/ComputerSystemCollection.json>;rel=describedby"
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Length:
+      - '524'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id": "/redfish/v1/Systems", "@redfish.copyright": "Copyright  2017  Dell,
-        Inc.  All rights reserved", "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
-        "Description": "Collection of Computer Systems", "Members@odata.count": 1,
-        "Name": "Computer System Collection", "Members": [{"@odata.id": "/redfish/v1/Systems/System.Embedded.1"}],
-        "@odata.context": "/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection"}'
+      string: |-
+        {
+            "@odata.id": "/redfish/v1/Systems",
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+            "Description": "Collection of Computer Systems",
+            "Members@odata.count": 1,
+            "Name": "Computer System Collection",
+            "Members": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1"
+                }
+            ],
+            "@odata.context": "/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection"
+        }
     http_version: 
-  recorded_at: Mon, 28 May 2018 07:15:35 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:58 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -119,71 +140,206 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      User-Agent:
+      - excon/0.62.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - a17159f6-f554-478f-afcb-73cba94b242e
+      - dummy
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - Apache/2.4
+      Cache-Control:
+      - no-cache
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Allow:
+      - POST,PATCH
+      Access-Control-Allow-Origin:
+      - "*"
       Date:
-      - Mon, 28 May 2018 07:15:35 GMT
+      - Sat, 20 May 2017 09:58:17 GMT
       Odata-Version:
       - '4.0'
-      Content-Type:
-      - application/json
+      Link:
+      - "</redfish/v1/Schemas/ComputerSystem.v1_1_0.json>;rel=describedby"
+      Content-Length:
+      - '5262'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"SimpleStorage": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},
-        "Links": {"CooledBy@odata.count": 12, "PoweredBy@odata.count": 0, "Oem": {"Dell":
-        {"BootSources": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"},
-        "@odata.type": "#Dell.v1_0_0.BootSources"}}, "ManagedBy": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}],
-        "Chassis": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1"}], "Chassis@odata.count":
-        1, "PoweredBy": [], "CooledBy": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],
-        "ManagedBy@odata.count": 1}, "Processors": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"},
-        "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
-        "Manufacturer": "Dell Inc.", "PowerState": "Off", "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
-        "Name": "System", "AssetTag": "", "HostName": "", "SerialNumber": "CN701636AB0013",
-        "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem", "TrustedModules":
-        [{"Status": {"State": "Disabled"}}], "IndicatorLED": "Off", "SKU": "", "MemorySummary":
-        {"TotalSystemMemoryGiB": 32.0, "Status": {"State": "Enabled", "Health": null,
-        "HealthRollup": null}, "MemoryMirroring": "System"}, "Model": "DSS9630M",
-        "@odata.id": "/redfish/v1/Systems/System.Embedded.1", "Id": "System.Embedded.1",
-        "Bios": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"}, "SecureBoot":
-        {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"}, "ProcessorSummary":
-        {"Status": {"State": "Enabled", "Health": null, "HealthRollup": null}, "Count":
-        2, "Model": ""}, "SystemType": "Physical", "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
-        "PartNumber": "033RF3X04", "BiosVersion": "0.4.8", "EthernetInterfaces": {"@odata.id":
-        "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"}, "Description":
-        "Computer System which represents a machine (physical or virtual) and the
-        local resources such as memory, cpu and other devices that can be accessed
-        from that machine.", "Actions": {"#ComputerSystem.Reset": {"target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
-        "ResetType@Redfish.AllowableValues": ["On", "ForceOff", "GracefulRestart",
-        "GracefulShutdown", "PushPowerButton", "Nmi"]}}, "Boot": {"UefiTargetBootSourceOverride":
-        "", "BootSourceOverrideTarget": "None", "BootSourceOverrideTarget@Redfish.AllowableValues":
-        ["None", "Pxe", "Floppy", "Cd", "Hdd", "BiosSetup", "Utilities", "UefiTarget",
-        "SDCard", "UefiHttp"], "BootSourceOverrideEnabled": "Once", "BootSourceOverrideMode":
-        "UEFI"}, "Status": {"State": "StandbyOffline", "Health": "OK", "HealthRollup":
-        "OK"}}'
+      string: |-
+        {
+            "SimpleStorage": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"
+            },
+            "Links": {
+                "CooledBy@odata.count": 12,
+                "PoweredBy@odata.count": 0,
+                "Oem": {
+                    "Dell": {
+                        "BootSources": {
+                            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"
+                        },
+                        "@odata.type": "#Dell.v1_0_0.BootSources"
+                    }
+                },
+                "ManagedBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"
+                    }
+                ],
+                "Chassis": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1"
+                    }
+                ],
+                "Chassis@odata.count": 1,
+                "PoweredBy": [],
+                "CooledBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"
+                    }
+                ],
+                "ManagedBy@odata.count": 1
+            },
+            "Processors": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"
+            },
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "Manufacturer": "Dell Inc.",
+            "PowerState": "Off",
+            "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            "Name": "System",
+            "AssetTag": "",
+            "HostName": "",
+            "SerialNumber": "CN701636AB0013",
+            "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem",
+            "TrustedModules": [
+                {
+                    "Status": {
+                        "State": "Disabled"
+                    }
+                }
+            ],
+            "IndicatorLED": "Off",
+            "SKU": "",
+            "MemorySummary": {
+                "TotalSystemMemoryGiB": 32.0,
+                "Status": {
+                    "State": "Enabled",
+                    "Health": null,
+                    "HealthRollup": null
+                },
+                "MemoryMirroring": "System"
+            },
+            "Model": "DSS9630M",
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1",
+            "Id": "System.Embedded.1",
+            "Bios": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"
+            },
+            "SecureBoot": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"
+            },
+            "ProcessorSummary": {
+                "Status": {
+                    "State": "Enabled",
+                    "Health": null,
+                    "HealthRollup": null
+                },
+                "Count": 2,
+                "Model": ""
+            },
+            "SystemType": "Physical",
+            "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+            "PartNumber": "033RF3X04",
+            "BiosVersion": "0.4.8",
+            "EthernetInterfaces": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"
+            },
+            "Description": "Computer System which represents a machine (physical or virtual) and the local resources such as memory, cpu and other devices that can be accessed from that machine.",
+            "Actions": {
+                "#ComputerSystem.Reset": {
+                    "target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+                    "ResetType@Redfish.AllowableValues": [
+                        "On",
+                        "ForceOff",
+                        "GracefulRestart",
+                        "GracefulShutdown",
+                        "PushPowerButton",
+                        "Nmi"
+                    ]
+                }
+            },
+            "Boot": {
+                "UefiTargetBootSourceOverride": "",
+                "BootSourceOverrideTarget": "None",
+                "BootSourceOverrideTarget@Redfish.AllowableValues": [
+                    "None",
+                    "Pxe",
+                    "Floppy",
+                    "Cd",
+                    "Hdd",
+                    "BiosSetup",
+                    "Utilities",
+                    "UefiTarget",
+                    "SDCard",
+                    "UefiHttp"
+                ],
+                "BootSourceOverrideEnabled": "Once",
+                "BootSourceOverrideMode": "UEFI"
+            },
+            "Status": {
+                "State": "StandbyOffline",
+                "Health": "OK",
+                "HealthRollup": "OK"
+            }
+        }
     http_version: 
-  recorded_at: Mon, 28 May 2018 07:15:35 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:58 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/System.Embedded.1
@@ -191,62 +347,588 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      User-Agent:
+      - excon/0.62.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - a17159f6-f554-478f-afcb-73cba94b242e
+      - dummy
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - Apache/2.4
+      Cache-Control:
+      - no-cache
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Allow:
+      - POST,PATCH
+      Access-Control-Allow-Origin:
+      - "*"
       Date:
-      - Mon, 28 May 2018 07:15:35 GMT
+      - Sat, 20 May 2017 09:58:22 GMT
       Odata-Version:
       - '4.0'
-      Content-Type:
-      - application/json
+      Link:
+      - "</redfish/v1/Schemas/Chassis.v1_0_2.json>;rel=describedby"
+      Content-Length:
+      - '3986'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"Links": {"Contains": [], "ComputerSystems": [{"@odata.id": "/redfish/v1/Systems/System.Embedded.1"}],
-        "PoweredBy@odata.count": 0, "PoweredBy": [], "CooledBy@odata.count": 12, "ManagersInChassis":
-        [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}], "Contains@odata.count":
-        0, "CooledBy": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],
-        "ManagersInChassis@odata.count": 1, "ManagedBy": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}],
-        "ComputerSystems@odata.count": 1, "ManagedBy@odata.count": 1}, "@redfish.copyright":
-        "Copyright  2017  Dell, Inc.  All rights reserved", "Manufacturer": "Dell
-        Inc.", "PowerState": "Off", "Thermal": {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal"},
-        "Name": "Computer System Chassis", "AssetTag": null, "SerialNumber": "CN701636AB0013",
-        "PhysicalSecurity": {"IntrusionSensor": null, "IntrusionSensorReArm": null,
-        "IntrusionSensorNumber": null}, "@odata.type": "#Chassis.v1_2_0.Chassis",
-        "IndicatorLED": "Off", "SKU": null, "Actions": {"#Chassis.Reset": {"target":
-        "/redfish/v1/Chassis/System.Embedded.1/Actions/Chassis.Reset", "ResetType@Redfish.AllowableValues":
-        ["On", "ForceOff"]}}, "Model": "DSS9630M", "@odata.id": "/redfish/v1/Chassis/System.Embedded.1",
-        "Id": "System.Embedded.1", "Power": {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Power"},
-        "PartNumber": "033RF3X04", "@odata.context": "/redfish/v1/$metadata#Chassis.Chassis",
-        "Location": {"Info": null, "InfoFormat": null}, "Status": {"State": "Enabled",
-        "Health": "OK", "HealthRollup": "OK"}, "Description": "It represents the properties
-        for physical components for any system.It represent racks, rackmount servers,
-        blades, standalone, modular systems,enclosures, and all other containers.The
-        non-cpu/device centric parts of the schema are all accessed either directly
-        or indirectly through this resource.", "ChassisType": "Enclosure"}'
+      string: |-
+        {
+            "Links": {
+                "Contains": [],
+                "ComputerSystems": [
+                    {
+                        "@odata.id": "/redfish/v1/Systems/System.Embedded.1"
+                    }
+                ],
+                "PoweredBy@odata.count": 0,
+                "PoweredBy": [],
+                "CooledBy@odata.count": 12,
+                "ManagersInChassis": [
+                    {
+                        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"
+                    }
+                ],
+                "Contains@odata.count": 0,
+                "CooledBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"
+                    }
+                ],
+                "ManagersInChassis@odata.count": 1,
+                "ManagedBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"
+                    }
+                ],
+                "ComputerSystems@odata.count": 1,
+                "ManagedBy@odata.count": 1
+            },
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "Manufacturer": "Dell Inc.",
+            "PowerState": "Off",
+            "Thermal": {
+                "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal"
+            },
+            "Name": "Computer System Chassis",
+            "AssetTag": null,
+            "SerialNumber": "CN701636AB0013",
+            "PhysicalSecurity": {
+                "IntrusionSensor": null,
+                "IntrusionSensorReArm": null,
+                "IntrusionSensorNumber": null
+            },
+            "@odata.type": "#Chassis.v1_2_0.Chassis",
+            "IndicatorLED": "Off",
+            "SKU": null,
+            "Actions": {
+                "#Chassis.Reset": {
+                    "target": "/redfish/v1/Chassis/System.Embedded.1/Actions/Chassis.Reset",
+                    "ResetType@Redfish.AllowableValues": [
+                        "On",
+                        "ForceOff"
+                    ]
+                }
+            },
+            "Model": "DSS9630M",
+            "@odata.id": "/redfish/v1/Chassis/System.Embedded.1",
+            "Id": "System.Embedded.1",
+            "Power": {
+                "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Power"
+            },
+            "PartNumber": "033RF3X04",
+            "@odata.context": "/redfish/v1/$metadata#Chassis.Chassis",
+            "Location": {
+                "Info": null,
+                "InfoFormat": null
+            },
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK",
+                "HealthRollup": "OK"
+            },
+            "Description": "It represents the properties for physical components for any system.It represent racks, rackmount servers, blades, standalone, modular systems,enclosures, and all other containers.The non-cpu/device centric parts of the schema are all accessed either directly or indirectly through this resource.",
+            "ChassisType": "Enclosure"
+        }
     http_version: 
-  recorded_at: Mon, 28 May 2018 07:15:35 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:58 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Processors
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - dummy
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Server:
+      - Apache/2.4
+      Date:
+      - Sat, 20 May 2017 09:58:18 GMT
+      Odata-Version:
+      - '4.0'
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Link:
+      - "</redfish/v1/Schemas/ProcessorCollection.json>;rel=describedby"
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Length:
+      - '890'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors",
+            "Members": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.2"
+                }
+            ],
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "@odata.type": "#ProcessorCollection.ProcessorCollection",
+            "Description": "Collection of Processors for this System",
+            "Members@odata.count": 2,
+            "Name": "ProcessorsCollection",
+            "@Message.ExtendedInfo": {
+                "Resolution": "Switch-On Host System and retry",
+                "MessageId": "Base.1.0.ObjectInfo",
+                "Message": "Host system is switched-off",
+                "Severity": "WARNING"
+            },
+            "@odata.context": "/redfish/v1/$metadata#ProcessorCollection.ProcessorCollection"
+        }
+    http_version: 
+  recorded_at: Wed, 13 Jun 2018 13:52:58 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - dummy
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Server:
+      - Apache/2.4
+      Date:
+      - Sat, 20 May 2017 09:58:19 GMT
+      Odata-Version:
+      - '4.0'
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Link:
+      - "</redfish/v1/Schemas/Processor.v1_0_2.json>;rel=describedby"
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Length:
+      - '1272'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.1",
+            "Id": "CPU.Socket.1",
+            "ProcessorId": {
+                "VendorId": "GenuineIntel",
+                "Step": "2",
+                "EffectiveFamily": "6",
+                "MicrocodeInfo": null,
+                "EffectiveModel": "85",
+                "IdentificationRegisters": "0x00050652"
+            },
+            "Description": "Represents the properties of a Processor attached to this System",
+            "Manufacturer": "Intel",
+            "TotalCores": 20,
+            "Name": "CPU 1",
+            "ProcessorArchitecture": [
+                {
+                    "Member": "x86"
+                }
+            ],
+            "Model": "",
+            "@odata.context": "/redfish/v1/$metadata#Processor.Processor",
+            "Status": {
+                "State": null,
+                "Health": null
+            },
+            "TotalThreads": 40,
+            "Socket": "CPU.Socket.1",
+            "ProcessorType": "CPU",
+            "@odata.type": "#Processor.v1_0_2.Processor",
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "InstructionSet": [
+                {
+                    "Member": "x86-64"
+                }
+            ],
+            "MaxSpeedMHz": 4000,
+            "@Message.ExtendedInfo": {
+                "Resolution": "Switch-On Host System and retry",
+                "MessageId": "Base.1.0.ObjectInfo",
+                "Message": "Host system is switched-off",
+                "Severity": "WARNING"
+            }
+        }
+    http_version: 
+  recorded_at: Wed, 13 Jun 2018 13:52:58 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - dummy
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Server:
+      - Apache/2.4
+      Date:
+      - Sat, 20 May 2017 09:58:19 GMT
+      Odata-Version:
+      - '4.0'
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Link:
+      - "</redfish/v1/Schemas/Processor.v1_0_2.json>;rel=describedby"
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Length:
+      - '1272'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.2",
+            "Id": "CPU.Socket.2",
+            "ProcessorId": {
+                "VendorId": "GenuineIntel",
+                "Step": "2",
+                "EffectiveFamily": "6",
+                "MicrocodeInfo": null,
+                "EffectiveModel": "85",
+                "IdentificationRegisters": "0x00050652"
+            },
+            "Description": "Represents the properties of a Processor attached to this System",
+            "Manufacturer": "Intel",
+            "TotalCores": 20,
+            "Name": "CPU 2",
+            "ProcessorArchitecture": [
+                {
+                    "Member": "x86"
+                }
+            ],
+            "Model": "",
+            "@odata.context": "/redfish/v1/$metadata#Processor.Processor",
+            "Status": {
+                "State": null,
+                "Health": null
+            },
+            "TotalThreads": 40,
+            "Socket": "CPU.Socket.2",
+            "ProcessorType": "CPU",
+            "@odata.type": "#Processor.v1_0_2.Processor",
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "InstructionSet": [
+                {
+                    "Member": "x86-64"
+                }
+            ],
+            "MaxSpeedMHz": 4000,
+            "@Message.ExtendedInfo": {
+                "Resolution": "Switch-On Host System and retry",
+                "MessageId": "Base.1.0.ObjectInfo",
+                "Message": "Host system is switched-off",
+                "Severity": "WARNING"
+            }
+        }
+    http_version: 
+  recorded_at: Wed, 13 Jun 2018 13:52:58 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Storage/Controllers
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - dummy
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Server:
+      - Apache/2.4
+      Date:
+      - Sat, 20 May 2017 09:58:17 GMT
+      Odata-Version:
+      - '4.0'
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Link:
+      - "</redfish/v1/Schemas/SimpleStorageCollection.json>;rel=describedby"
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Length:
+      - '730'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers",
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "@odata.type": "#SimpleStorageCollection.SimpleStorageCollection",
+            "Description": "Collection of Controllers for this system",
+            "Members@odata.count": 2,
+            "Name": "Simple Storage Collection",
+            "Members": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.2-1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.1-1"
+                }
+            ],
+            "@odata.context": "/redfish/v1/$metadata#SimpleStorageCollection.SimpleStorageCollection"
+        }
+    http_version: 
+  recorded_at: Wed, 13 Jun 2018 13:52:58 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.2-1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - dummy
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Server:
+      - Apache/2.4
+      Date:
+      - Sat, 20 May 2017 09:58:18 GMT
+      Odata-Version:
+      - '4.0'
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Link:
+      - "</redfish/v1/Schemas/SimpleStorage.v1_0_2.json>;rel=describedby"
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Length:
+      - '646'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.2-1",
+            "Id": "AHCI.Embedded.2-1",
+            "Devices": [],
+            "@odata.type": "#SimpleStorage.v1_0_2.SimpleStorage",
+            "Description": "Simple Storage Controller",
+            "Status": {
+                "State": "Enabled",
+                "Health": null,
+                "HealthRollup": null
+            },
+            "Devices@odata.count": 0,
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "Name": "Lewisburg SATA Controller [AHCI mode]",
+            "UefiDevicePath": "PciRoot(0x0)/Pci(0x17,0x0)",
+            "@odata.context": "/redfish/v1/$metadata#SimpleStorage.SimpleStorage"
+        }
+    http_version: 
+  recorded_at: Wed, 13 Jun 2018 13:52:58 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.1-1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - dummy
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Server:
+      - Apache/2.4
+      Date:
+      - Sat, 20 May 2017 09:58:18 GMT
+      Odata-Version:
+      - '4.0'
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Link:
+      - "</redfish/v1/Schemas/SimpleStorage.v1_0_2.json>;rel=describedby"
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Length:
+      - '647'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.1-1",
+            "Id": "AHCI.Embedded.1-1",
+            "Devices": [],
+            "@odata.type": "#SimpleStorage.v1_0_2.SimpleStorage",
+            "Description": "Simple Storage Controller",
+            "Status": {
+                "State": "Enabled",
+                "Health": null,
+                "HealthRollup": null
+            },
+            "Devices@odata.count": 0,
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "Name": "Lewisburg SSATA Controller [AHCI mode]",
+            "UefiDevicePath": "PciRoot(0x0)/Pci(0x11,0x5)",
+            "@odata.context": "/redfish/v1/$metadata#SimpleStorage.SimpleStorage"
+        }
+    http_version: 
+  recorded_at: Wed, 13 Jun 2018 13:52:58 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1
@@ -254,6 +936,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      User-Agent:
+      - excon/0.62.0
       Accept:
       - application/json
       Odata-Version:
@@ -261,33 +945,27 @@ http_interactions:
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
-      Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
-      Date:
-      - Mon, 28 May 2018 07:15:35 GMT
-      Odata-Version:
-      - '4.0'
       Content-Type:
       - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Wed, 13 Jun 2018 13:52:58 GMT
+      Content-Length:
+      - '1000'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context": "/redfish/v1/$metadata#ServiceRoot.ServiceRoot",
-        "@odata.id": "/redfish/v1", "@odata.type": "#ServiceRoot.v1_1_0.ServiceRoot",
-        "AccountService": {"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},
-        "Chassis": {"@odata.id": "/redfish/v1/Chassis"}, "Description": "Root Service",
-        "EventService": {"@odata.id": "/redfish/v1/EventService"}, "Id": "RootService",
-        "JsonSchemas": {"@odata.id": "/redfish/v1/JSONSchemas"}, "Links": {"Sessions":
-        {"@odata.id": "/redfish/v1/Sessions"}}, "Managers": {"@odata.id": "/redfish/v1/Managers"},
-        "Name": "Root Service", "Oem": {"Dell": {"@odata.type": "/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot",
-        "IsBranded": 0, "ManagerMACAddress": "10:98:36:a9:05:b0", "ServiceTag": ""}},
-        "RedfishVersion": "1.0.2", "Registries": {"@odata.id": "/redfish/v1/Registries"},
-        "SessionService": {"@odata.id": "/redfish/v1/SessionService"}, "Systems":
-        {"@odata.id": "/redfish/v1/Systems"}, "Tasks": {"@odata.id": "/redfish/v1/TaskService"},
-        "UpdateService": {"@odata.id": "/redfish/v1/UpdateService"}}'
+      string: '{"@odata.context":"/redfish/v1/$metadata#ServiceRoot.ServiceRoot","@odata.id":"/redfish/v1","@odata.type":"#ServiceRoot.v1_1_0.ServiceRoot","AccountService":{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},"Chassis":{"@odata.id":"/redfish/v1/Chassis"},"Description":"Root
+        Service","EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","JsonSchemas":{"@odata.id":"/redfish/v1/JSONSchemas"},"Links":{"Sessions":{"@odata.id":"/redfish/v1/Sessions"}},"Managers":{"@odata.id":"/redfish/v1/Managers"},"Name":"Root
+        Service","Oem":{"Dell":{"@odata.type":"/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot","IsBranded":0,"ManagerMACAddress":"10:98:36:a9:05:b0","ServiceTag":""}},"RedfishVersion":"1.0.2","Registries":{"@odata.id":"/redfish/v1/Registries"},"SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"Tasks":{"@odata.id":"/redfish/v1/TaskService"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}
+
+'
     http_version: 
-  recorded_at: Mon, 28 May 2018 07:15:35 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:58 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
@@ -295,35 +973,36 @@ http_interactions:
       encoding: UTF-8
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
     headers:
+      User-Agent:
+      - excon/0.62.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
+      Content-Type:
+      - application/json
   response:
     status:
       code: 201
-      message: Created
+      message: 'Created '
     headers:
-      Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
-      Date:
-      - Mon, 28 May 2018 07:15:35 GMT
-      Odata-Version:
-      - '4.0'
       Content-Type:
       - application/json
-      Location:
-      - "/redfish/v1/Sessions/6d5c8654-ab28-4390-bec0-e772dca581cc"
       X-Auth-Token:
-      - 0ca89eb7-aa54-406a-89f7-6c998ec9a9b8
+      - dummy
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Wed, 13 Jun 2018 13:52:58 GMT
+      Content-Length:
+      - '71'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context": "/redfish/v1/$metadata#Session.Session", "@odata.type":
-        "#Session.v1_0_0.Session", "Name": "User Session", "Description": "User Session",
-        "UserName": "REDFISH_USERID", "@odata.id": "/redfish/v1/Sessions/6d5c8654-ab28-4390-bec0-e772dca581cc",
-        "Id": "6d5c8654-ab28-4390-bec0-e772dca581cc"}'
+      string: '{"Name":"User Session","Description":"User Session","UserName":"REDFISH_USERID"}'
     http_version: 
-  recorded_at: Mon, 28 May 2018 07:15:35 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:58 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems
@@ -331,34 +1010,58 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      User-Agent:
+      - excon/0.62.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 0ca89eb7-aa54-406a-89f7-6c998ec9a9b8
+      - dummy
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - Apache/2.4
       Date:
-      - Mon, 28 May 2018 07:15:35 GMT
+      - Sat, 20 May 2017 09:58:16 GMT
       Odata-Version:
       - '4.0'
+      X-Frame-Options:
+      - DENY
       Content-Type:
-      - application/json
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Link:
+      - "</redfish/v1/Schemas/ComputerSystemCollection.json>;rel=describedby"
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Length:
+      - '524'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id": "/redfish/v1/Systems", "@redfish.copyright": "Copyright  2017  Dell,
-        Inc.  All rights reserved", "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
-        "Description": "Collection of Computer Systems", "Members@odata.count": 1,
-        "Name": "Computer System Collection", "Members": [{"@odata.id": "/redfish/v1/Systems/System.Embedded.1"}],
-        "@odata.context": "/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection"}'
+      string: |-
+        {
+            "@odata.id": "/redfish/v1/Systems",
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+            "Description": "Collection of Computer Systems",
+            "Members@odata.count": 1,
+            "Name": "Computer System Collection",
+            "Members": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1"
+                }
+            ],
+            "@odata.context": "/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection"
+        }
     http_version: 
-  recorded_at: Mon, 28 May 2018 07:15:35 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -366,71 +1069,206 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      User-Agent:
+      - excon/0.62.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 0ca89eb7-aa54-406a-89f7-6c998ec9a9b8
+      - dummy
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - Apache/2.4
+      Cache-Control:
+      - no-cache
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Allow:
+      - POST,PATCH
+      Access-Control-Allow-Origin:
+      - "*"
       Date:
-      - Mon, 28 May 2018 07:15:35 GMT
+      - Sat, 20 May 2017 09:58:17 GMT
       Odata-Version:
       - '4.0'
-      Content-Type:
-      - application/json
+      Link:
+      - "</redfish/v1/Schemas/ComputerSystem.v1_1_0.json>;rel=describedby"
+      Content-Length:
+      - '5262'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"SimpleStorage": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},
-        "Links": {"CooledBy@odata.count": 12, "PoweredBy@odata.count": 0, "Oem": {"Dell":
-        {"BootSources": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"},
-        "@odata.type": "#Dell.v1_0_0.BootSources"}}, "ManagedBy": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}],
-        "Chassis": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1"}], "Chassis@odata.count":
-        1, "PoweredBy": [], "CooledBy": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],
-        "ManagedBy@odata.count": 1}, "Processors": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"},
-        "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
-        "Manufacturer": "Dell Inc.", "PowerState": "Off", "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
-        "Name": "System", "AssetTag": "", "HostName": "", "SerialNumber": "CN701636AB0013",
-        "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem", "TrustedModules":
-        [{"Status": {"State": "Disabled"}}], "IndicatorLED": "Off", "SKU": "", "MemorySummary":
-        {"TotalSystemMemoryGiB": 32.0, "Status": {"State": "Enabled", "Health": null,
-        "HealthRollup": null}, "MemoryMirroring": "System"}, "Model": "DSS9630M",
-        "@odata.id": "/redfish/v1/Systems/System.Embedded.1", "Id": "System.Embedded.1",
-        "Bios": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"}, "SecureBoot":
-        {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"}, "ProcessorSummary":
-        {"Status": {"State": "Enabled", "Health": null, "HealthRollup": null}, "Count":
-        2, "Model": ""}, "SystemType": "Physical", "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
-        "PartNumber": "033RF3X04", "BiosVersion": "0.4.8", "EthernetInterfaces": {"@odata.id":
-        "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"}, "Description":
-        "Computer System which represents a machine (physical or virtual) and the
-        local resources such as memory, cpu and other devices that can be accessed
-        from that machine.", "Actions": {"#ComputerSystem.Reset": {"target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
-        "ResetType@Redfish.AllowableValues": ["On", "ForceOff", "GracefulRestart",
-        "GracefulShutdown", "PushPowerButton", "Nmi"]}}, "Boot": {"UefiTargetBootSourceOverride":
-        "", "BootSourceOverrideTarget": "None", "BootSourceOverrideTarget@Redfish.AllowableValues":
-        ["None", "Pxe", "Floppy", "Cd", "Hdd", "BiosSetup", "Utilities", "UefiTarget",
-        "SDCard", "UefiHttp"], "BootSourceOverrideEnabled": "Once", "BootSourceOverrideMode":
-        "UEFI"}, "Status": {"State": "StandbyOffline", "Health": "OK", "HealthRollup":
-        "OK"}}'
+      string: |-
+        {
+            "SimpleStorage": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"
+            },
+            "Links": {
+                "CooledBy@odata.count": 12,
+                "PoweredBy@odata.count": 0,
+                "Oem": {
+                    "Dell": {
+                        "BootSources": {
+                            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources"
+                        },
+                        "@odata.type": "#Dell.v1_0_0.BootSources"
+                    }
+                },
+                "ManagedBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"
+                    }
+                ],
+                "Chassis": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1"
+                    }
+                ],
+                "Chassis@odata.count": 1,
+                "PoweredBy": [],
+                "CooledBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"
+                    }
+                ],
+                "ManagedBy@odata.count": 1
+            },
+            "Processors": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"
+            },
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "Manufacturer": "Dell Inc.",
+            "PowerState": "Off",
+            "UUID": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            "Name": "System",
+            "AssetTag": "",
+            "HostName": "",
+            "SerialNumber": "CN701636AB0013",
+            "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem",
+            "TrustedModules": [
+                {
+                    "Status": {
+                        "State": "Disabled"
+                    }
+                }
+            ],
+            "IndicatorLED": "Off",
+            "SKU": "",
+            "MemorySummary": {
+                "TotalSystemMemoryGiB": 32.0,
+                "Status": {
+                    "State": "Enabled",
+                    "Health": null,
+                    "HealthRollup": null
+                },
+                "MemoryMirroring": "System"
+            },
+            "Model": "DSS9630M",
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1",
+            "Id": "System.Embedded.1",
+            "Bios": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"
+            },
+            "SecureBoot": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"
+            },
+            "ProcessorSummary": {
+                "Status": {
+                    "State": "Enabled",
+                    "Health": null,
+                    "HealthRollup": null
+                },
+                "Count": 2,
+                "Model": ""
+            },
+            "SystemType": "Physical",
+            "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+            "PartNumber": "033RF3X04",
+            "BiosVersion": "0.4.8",
+            "EthernetInterfaces": {
+                "@odata.id": "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"
+            },
+            "Description": "Computer System which represents a machine (physical or virtual) and the local resources such as memory, cpu and other devices that can be accessed from that machine.",
+            "Actions": {
+                "#ComputerSystem.Reset": {
+                    "target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+                    "ResetType@Redfish.AllowableValues": [
+                        "On",
+                        "ForceOff",
+                        "GracefulRestart",
+                        "GracefulShutdown",
+                        "PushPowerButton",
+                        "Nmi"
+                    ]
+                }
+            },
+            "Boot": {
+                "UefiTargetBootSourceOverride": "",
+                "BootSourceOverrideTarget": "None",
+                "BootSourceOverrideTarget@Redfish.AllowableValues": [
+                    "None",
+                    "Pxe",
+                    "Floppy",
+                    "Cd",
+                    "Hdd",
+                    "BiosSetup",
+                    "Utilities",
+                    "UefiTarget",
+                    "SDCard",
+                    "UefiHttp"
+                ],
+                "BootSourceOverrideEnabled": "Once",
+                "BootSourceOverrideMode": "UEFI"
+            },
+            "Status": {
+                "State": "StandbyOffline",
+                "Health": "OK",
+                "HealthRollup": "OK"
+            }
+        }
     http_version: 
-  recorded_at: Mon, 28 May 2018 07:15:35 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/System.Embedded.1
@@ -438,60 +1276,586 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      User-Agent:
+      - excon/0.62.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 0ca89eb7-aa54-406a-89f7-6c998ec9a9b8
+      - dummy
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
       Server:
-      - RedfishMockupHTTPD_v1.0.0 Python/3.6.5
+      - Apache/2.4
+      Cache-Control:
+      - no-cache
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Allow:
+      - POST,PATCH
+      Access-Control-Allow-Origin:
+      - "*"
       Date:
-      - Mon, 28 May 2018 07:15:35 GMT
+      - Sat, 20 May 2017 09:58:22 GMT
       Odata-Version:
       - '4.0'
-      Content-Type:
-      - application/json
+      Link:
+      - "</redfish/v1/Schemas/Chassis.v1_0_2.json>;rel=describedby"
+      Content-Length:
+      - '3986'
+      Connection:
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"Links": {"Contains": [], "ComputerSystems": [{"@odata.id": "/redfish/v1/Systems/System.Embedded.1"}],
-        "PoweredBy@odata.count": 0, "PoweredBy": [], "CooledBy@odata.count": 12, "ManagersInChassis":
-        [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}], "Contains@odata.count":
-        0, "CooledBy": [{"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},
-        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],
-        "ManagersInChassis@odata.count": 1, "ManagedBy": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}],
-        "ComputerSystems@odata.count": 1, "ManagedBy@odata.count": 1}, "@redfish.copyright":
-        "Copyright  2017  Dell, Inc.  All rights reserved", "Manufacturer": "Dell
-        Inc.", "PowerState": "Off", "Thermal": {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal"},
-        "Name": "Computer System Chassis", "AssetTag": null, "SerialNumber": "CN701636AB0013",
-        "PhysicalSecurity": {"IntrusionSensor": null, "IntrusionSensorReArm": null,
-        "IntrusionSensorNumber": null}, "@odata.type": "#Chassis.v1_2_0.Chassis",
-        "IndicatorLED": "Off", "SKU": null, "Actions": {"#Chassis.Reset": {"target":
-        "/redfish/v1/Chassis/System.Embedded.1/Actions/Chassis.Reset", "ResetType@Redfish.AllowableValues":
-        ["On", "ForceOff"]}}, "Model": "DSS9630M", "@odata.id": "/redfish/v1/Chassis/System.Embedded.1",
-        "Id": "System.Embedded.1", "Power": {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Power"},
-        "PartNumber": "033RF3X04", "@odata.context": "/redfish/v1/$metadata#Chassis.Chassis",
-        "Location": {"Info": null, "InfoFormat": null}, "Status": {"State": "Enabled",
-        "Health": "OK", "HealthRollup": "OK"}, "Description": "It represents the properties
-        for physical components for any system.It represent racks, rackmount servers,
-        blades, standalone, modular systems,enclosures, and all other containers.The
-        non-cpu/device centric parts of the schema are all accessed either directly
-        or indirectly through this resource.", "ChassisType": "Enclosure"}'
+      string: |-
+        {
+            "Links": {
+                "Contains": [],
+                "ComputerSystems": [
+                    {
+                        "@odata.id": "/redfish/v1/Systems/System.Embedded.1"
+                    }
+                ],
+                "PoweredBy@odata.count": 0,
+                "PoweredBy": [],
+                "CooledBy@odata.count": 12,
+                "ManagersInChassis": [
+                    {
+                        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"
+                    }
+                ],
+                "Contains@odata.count": 0,
+                "CooledBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"
+                    },
+                    {
+                        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"
+                    }
+                ],
+                "ManagersInChassis@odata.count": 1,
+                "ManagedBy": [
+                    {
+                        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"
+                    }
+                ],
+                "ComputerSystems@odata.count": 1,
+                "ManagedBy@odata.count": 1
+            },
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "Manufacturer": "Dell Inc.",
+            "PowerState": "Off",
+            "Thermal": {
+                "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal"
+            },
+            "Name": "Computer System Chassis",
+            "AssetTag": null,
+            "SerialNumber": "CN701636AB0013",
+            "PhysicalSecurity": {
+                "IntrusionSensor": null,
+                "IntrusionSensorReArm": null,
+                "IntrusionSensorNumber": null
+            },
+            "@odata.type": "#Chassis.v1_2_0.Chassis",
+            "IndicatorLED": "Off",
+            "SKU": null,
+            "Actions": {
+                "#Chassis.Reset": {
+                    "target": "/redfish/v1/Chassis/System.Embedded.1/Actions/Chassis.Reset",
+                    "ResetType@Redfish.AllowableValues": [
+                        "On",
+                        "ForceOff"
+                    ]
+                }
+            },
+            "Model": "DSS9630M",
+            "@odata.id": "/redfish/v1/Chassis/System.Embedded.1",
+            "Id": "System.Embedded.1",
+            "Power": {
+                "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Power"
+            },
+            "PartNumber": "033RF3X04",
+            "@odata.context": "/redfish/v1/$metadata#Chassis.Chassis",
+            "Location": {
+                "Info": null,
+                "InfoFormat": null
+            },
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK",
+                "HealthRollup": "OK"
+            },
+            "Description": "It represents the properties for physical components for any system.It represent racks, rackmount servers, blades, standalone, modular systems,enclosures, and all other containers.The non-cpu/device centric parts of the schema are all accessed either directly or indirectly through this resource.",
+            "ChassisType": "Enclosure"
+        }
     http_version: 
-  recorded_at: Mon, 28 May 2018 07:15:35 GMT
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Processors
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - dummy
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Server:
+      - Apache/2.4
+      Date:
+      - Sat, 20 May 2017 09:58:18 GMT
+      Odata-Version:
+      - '4.0'
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Link:
+      - "</redfish/v1/Schemas/ProcessorCollection.json>;rel=describedby"
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Length:
+      - '890'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors",
+            "Members": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.2"
+                }
+            ],
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "@odata.type": "#ProcessorCollection.ProcessorCollection",
+            "Description": "Collection of Processors for this System",
+            "Members@odata.count": 2,
+            "Name": "ProcessorsCollection",
+            "@Message.ExtendedInfo": {
+                "Resolution": "Switch-On Host System and retry",
+                "MessageId": "Base.1.0.ObjectInfo",
+                "Message": "Host system is switched-off",
+                "Severity": "WARNING"
+            },
+            "@odata.context": "/redfish/v1/$metadata#ProcessorCollection.ProcessorCollection"
+        }
+    http_version: 
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - dummy
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Server:
+      - Apache/2.4
+      Date:
+      - Sat, 20 May 2017 09:58:19 GMT
+      Odata-Version:
+      - '4.0'
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Link:
+      - "</redfish/v1/Schemas/Processor.v1_0_2.json>;rel=describedby"
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Length:
+      - '1272'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.1",
+            "Id": "CPU.Socket.1",
+            "ProcessorId": {
+                "VendorId": "GenuineIntel",
+                "Step": "2",
+                "EffectiveFamily": "6",
+                "MicrocodeInfo": null,
+                "EffectiveModel": "85",
+                "IdentificationRegisters": "0x00050652"
+            },
+            "Description": "Represents the properties of a Processor attached to this System",
+            "Manufacturer": "Intel",
+            "TotalCores": 20,
+            "Name": "CPU 1",
+            "ProcessorArchitecture": [
+                {
+                    "Member": "x86"
+                }
+            ],
+            "Model": "",
+            "@odata.context": "/redfish/v1/$metadata#Processor.Processor",
+            "Status": {
+                "State": null,
+                "Health": null
+            },
+            "TotalThreads": 40,
+            "Socket": "CPU.Socket.1",
+            "ProcessorType": "CPU",
+            "@odata.type": "#Processor.v1_0_2.Processor",
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "InstructionSet": [
+                {
+                    "Member": "x86-64"
+                }
+            ],
+            "MaxSpeedMHz": 4000,
+            "@Message.ExtendedInfo": {
+                "Resolution": "Switch-On Host System and retry",
+                "MessageId": "Base.1.0.ObjectInfo",
+                "Message": "Host system is switched-off",
+                "Severity": "WARNING"
+            }
+        }
+    http_version: 
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - dummy
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Server:
+      - Apache/2.4
+      Date:
+      - Sat, 20 May 2017 09:58:19 GMT
+      Odata-Version:
+      - '4.0'
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Link:
+      - "</redfish/v1/Schemas/Processor.v1_0_2.json>;rel=describedby"
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Length:
+      - '1272'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.2",
+            "Id": "CPU.Socket.2",
+            "ProcessorId": {
+                "VendorId": "GenuineIntel",
+                "Step": "2",
+                "EffectiveFamily": "6",
+                "MicrocodeInfo": null,
+                "EffectiveModel": "85",
+                "IdentificationRegisters": "0x00050652"
+            },
+            "Description": "Represents the properties of a Processor attached to this System",
+            "Manufacturer": "Intel",
+            "TotalCores": 20,
+            "Name": "CPU 2",
+            "ProcessorArchitecture": [
+                {
+                    "Member": "x86"
+                }
+            ],
+            "Model": "",
+            "@odata.context": "/redfish/v1/$metadata#Processor.Processor",
+            "Status": {
+                "State": null,
+                "Health": null
+            },
+            "TotalThreads": 40,
+            "Socket": "CPU.Socket.2",
+            "ProcessorType": "CPU",
+            "@odata.type": "#Processor.v1_0_2.Processor",
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "InstructionSet": [
+                {
+                    "Member": "x86-64"
+                }
+            ],
+            "MaxSpeedMHz": 4000,
+            "@Message.ExtendedInfo": {
+                "Resolution": "Switch-On Host System and retry",
+                "MessageId": "Base.1.0.ObjectInfo",
+                "Message": "Host system is switched-off",
+                "Severity": "WARNING"
+            }
+        }
+    http_version: 
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Storage/Controllers
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - dummy
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Server:
+      - Apache/2.4
+      Date:
+      - Sat, 20 May 2017 09:58:17 GMT
+      Odata-Version:
+      - '4.0'
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Link:
+      - "</redfish/v1/Schemas/SimpleStorageCollection.json>;rel=describedby"
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Length:
+      - '730'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers",
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "@odata.type": "#SimpleStorageCollection.SimpleStorageCollection",
+            "Description": "Collection of Controllers for this system",
+            "Members@odata.count": 2,
+            "Name": "Simple Storage Collection",
+            "Members": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.2-1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.1-1"
+                }
+            ],
+            "@odata.context": "/redfish/v1/$metadata#SimpleStorageCollection.SimpleStorageCollection"
+        }
+    http_version: 
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.2-1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - dummy
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Server:
+      - Apache/2.4
+      Date:
+      - Sat, 20 May 2017 09:58:18 GMT
+      Odata-Version:
+      - '4.0'
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Link:
+      - "</redfish/v1/Schemas/SimpleStorage.v1_0_2.json>;rel=describedby"
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Length:
+      - '646'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.2-1",
+            "Id": "AHCI.Embedded.2-1",
+            "Devices": [],
+            "@odata.type": "#SimpleStorage.v1_0_2.SimpleStorage",
+            "Description": "Simple Storage Controller",
+            "Status": {
+                "State": "Enabled",
+                "Health": null,
+                "HealthRollup": null
+            },
+            "Devices@odata.count": 0,
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "Name": "Lewisburg SATA Controller [AHCI mode]",
+            "UefiDevicePath": "PciRoot(0x0)/Pci(0x17,0x0)",
+            "@odata.context": "/redfish/v1/$metadata#SimpleStorage.SimpleStorage"
+        }
+    http_version: 
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.1-1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - dummy
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Server:
+      - Apache/2.4
+      Date:
+      - Sat, 20 May 2017 09:58:18 GMT
+      Odata-Version:
+      - '4.0'
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json;odata.metadata=minimal;charset=utf-8
+      Link:
+      - "</redfish/v1/Schemas/SimpleStorage.v1_0_2.json>;rel=describedby"
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Length:
+      - '647'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.1-1",
+            "Id": "AHCI.Embedded.1-1",
+            "Devices": [],
+            "@odata.type": "#SimpleStorage.v1_0_2.SimpleStorage",
+            "Description": "Simple Storage Controller",
+            "Status": {
+                "State": "Enabled",
+                "Health": null,
+                "HealthRollup": null
+            },
+            "Devices@odata.count": 0,
+            "@redfish.copyright": "Copyright  2017  Dell, Inc.  All rights reserved",
+            "Name": "Lewisburg SSATA Controller [AHCI mode]",
+            "UefiDevicePath": "PciRoot(0x0)/Pci(0x11,0x5)",
+            "@odata.context": "/redfish/v1/$metadata#SimpleStorage.SimpleStorage"
+        }
+    http_version: 
+  recorded_at: Wed, 13 Jun 2018 13:52:59 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Currently, only summary fields are set on hardware model.  Details
about the hardware components (disks, formwares, etc.) will be added
later on.

@miq-bot assign @Ladas 
@miq-bot add_reviewer @gberginc 
@miq-bot add_reviewer @agrare 

/cc @matejart 