### PR TITLE
Omit rack id field when storing physical server

### DIFF
--- a/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
@@ -24,8 +24,7 @@ module ManageIQ::Providers::Redfish
           :field_replaceable_unit => "dummy",
           :raw_power_state        => s["PowerState"],
           :vendor                 => "unknown",
-          :location_led_state     => s["IndicatorLED"],
-          :physical_rack_id       => 0
+          :location_led_state     => s["IndicatorLED"]
         )
         persister.computer_systems.build(:managed_entity => server)
       end

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
@@ -44,8 +44,7 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
       :field_replaceable_unit => "dummy",
       :raw_power_state        => "Off",
       :vendor                 => "unknown",
-      :location_led_state     => "Off",
-      :physical_rack_id       => 0
+      :location_led_state     => "Off"
     )
   end
 


### PR DESCRIPTION
Field in question should point to an existing physical rack. At the
moment, Redfish provider does not support adding racks to the
inventory, so this field should be omitted when saving the server.

@miq-bot assign @gtanzillo 
/cc @gberginc @matejart 