### PR TITLE
Lazy load PhysicalServer class in spec factory

### DIFF
--- a/spec/factories/physical_server.rb
+++ b/spec/factories/physical_server.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :redfish_physical_server,
-          :class  => ManageIQ::Providers::Redfish::PhysicalInfraManager::PhysicalServer,
+          :class  => "ManageIQ::Providers::Redfish::PhysicalInfraManager::PhysicalServer",
           :parent => :physical_server do
     trait :vcr do
       ems_ref "/redfish/v1/Systems/System.Embedded.1"


### PR DESCRIPTION
It seems that FactoryGirl can get into troubles when combined with
Rails' autoloading of classes, which manifests itself with a warning
similar to this: "toplevel constant SomeClassName referenced ...".

To bypass this problem, we force FactoryGirl to lazy load the class by
passing in a string instead of the actual class.

This should fix #15 