### PR TITLE
Move LED state from server to asset details

### DIFF
--- a/app/models/manageiq/providers/redfish/inventory/collector/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/inventory/collector/physical_infra_manager.rb
@@ -5,7 +5,7 @@ module ManageIQ::Providers::Redfish
     end
 
     def physical_server_details
-      rf_client.Systems.Members.collect { |s| get_server_location(s) }
+      rf_client.Systems.Members.collect { |s| get_server_details(s) }
     end
 
     def hardwares
@@ -13,6 +13,10 @@ module ManageIQ::Providers::Redfish
     end
 
     private
+
+    def get_server_details(server)
+      get_server_location(server).merge("IndicatorLED" => server.IndicatorLED)
+    end
 
     def get_server_location(server)
       loc = { :server_id => server["@odata.id"] }

--- a/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
@@ -25,7 +25,6 @@ module ManageIQ::Providers::Redfish
           :field_replaceable_unit => "dummy",
           :raw_power_state        => s["PowerState"],
           :vendor                 => "unknown",
-          :location_led_state     => s["IndicatorLED"]
         )
         persister.computer_systems.build(:managed_entity => server)
       end
@@ -38,13 +37,14 @@ module ManageIQ::Providers::Redfish
       collector.physical_server_details.each do |d|
         server = persister.physical_servers.lazy_find(d[:server_id])
         persister.physical_server_details.build(
-          :resource         => server,
-          :contact          => "",
-          :description      => "",
-          :location         => get_location(d),
-          :room             => "",
-          :rack_name        => get_rack(d),
-          :lowest_rack_unit => ""
+          :resource           => server,
+          :contact            => "",
+          :description        => "",
+          :location           => get_location(d),
+          :room               => "",
+          :rack_name          => get_rack(d),
+          :location_led_state => d["IndicatorLED"],
+          :lowest_rack_unit   => ""
         )
       end
     end

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
@@ -46,7 +46,6 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
       :field_replaceable_unit => "dummy",
       :raw_power_state        => "Off",
       :vendor                 => "unknown",
-      :location_led_state     => "Off"
     )
   end
 
@@ -55,7 +54,8 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
     # TODO(tadeboro): We need better source of data before we can create more
     #                 meaningful test.
     expect(d).to have_attributes(
-      :resource_type => "PhysicalServer"
+      :location_led_state => "Off",
+      :resource_type      => "PhysicalServer",
     )
   end
 


### PR DESCRIPTION
This fixes travis failures that were caused by https://github.com/ManageIQ/manageiq-schema/pull/262