### PR TITLE
Implement disconnect functionality

### DIFF
--- a/app/models/manageiq/providers/redfish/manager_mixin.rb
+++ b/app/models/manageiq/providers/redfish/manager_mixin.rb
@@ -17,6 +17,12 @@ module ManageIQ::Providers::Redfish::ManagerMixin
     self.class.raw_connect(username, password, host, port, protocol)
   end
 
+  def disconnect(connection)
+    connection.logout
+  rescue StandardError => error
+    $redfish_log.warn("Disconnect failed: #{error}")
+  end
+
   def verify_credentials(auth_type = nil, options = {})
     options[:auth_type] = auth_type
     with_provider_connection(options) { true }


### PR DESCRIPTION
Some Redfish implementations support extremely low number of concurrent user sessions. If those sessions are long lived (some servers only delete them after half an hour), ManageIQ can deplete
them relatively fast.

To remedy this scenario, we perform logout in disconnect method that is called after the connection is no longer needed. This should help keep number of active session to a minimum.

@miq-bot assign @agrare 