### PR TITLE
Move server info into asset details table

### DIFF
--- a/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
@@ -14,12 +14,9 @@ module ManageIQ::Providers::Redfish
           :ems_ref         => s["@odata.id"],
           :health_state    => s.Status.Health,
           :hostname        => s.HostName,
-          :manufacturer    => s.Manufacturer,
-          :model           => s.Model,
           :name            => s.Id,
           :power_state     => s.PowerState,
           :raw_power_state => s.PowerState,
-          :serial_number   => s.SerialNumber,
           :type            => "ManageIQ::Providers::Redfish::PhysicalInfraManager::PhysicalServer",
         )
         persister.computer_systems.build(:managed_entity => server)
@@ -34,8 +31,11 @@ module ManageIQ::Providers::Redfish
           :description        => s.Description,
           :location           => format_location(location),
           :location_led_state => s.IndicatorLED,
+          :manufacturer       => s.Manufacturer,
+          :model              => s.Model,
           :rack_name          => location.dig("Placement", "Rack"),
           :resource           => server,
+          :serial_number      => s.SerialNumber,
         )
       end
     end

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
@@ -35,23 +35,21 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
       :ems_id          => ems.id,
       :health_state    => "OK",
       :hostname        => "",
-      :manufacturer    => "Dell Inc.",
-      :model           => "DSS9630M",
       :name            => "System.Embedded.1",
       :power_state     => "Off",
       :raw_power_state => "Off",
-      :serial_number   => "CN701636AB0013",
       :type            => "ManageIQ::Providers::Redfish::PhysicalInfraManager::PhysicalServer",
     )
   end
 
   def assert_physical_server_details
     d = AssetDetail.find_by(:resource_type => "PhysicalServer")
-    # TODO(tadeboro): We need better source of data before we can create more
-    #                 meaningful test.
     expect(d).to have_attributes(
       :location_led_state => "Off",
+      :manufacturer       => "Dell Inc.",
+      :model              => "DSS9630M",
       :resource_type      => "PhysicalServer",
+      :serial_number      => "CN701636AB0013",
     )
   end
 


### PR DESCRIPTION
Moving details into asset details table makes them accessible to UI that is then capable of displaying them in the various server views (server lists, summary views, etc.).

@miq-bot assign @agrare 