### PR TITLE
Replace test data

### DIFF
--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_blink_loc_led/makes_location_LED_start_blinking.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_blink_loc_led/makes_location_LED_start_blinking.yml
@@ -23,21 +23,20 @@ http_interactions:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:39 GMT
+      - Mon, 24 Sep 2018 13:48:07 GMT
       Content-Length:
-      - '999'
+      - '362'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context":"/redfish/v1/$metadata#ServiceRoot.ServiceRoot","@odata.id":"/redfish/v1","@odata.type":"#ServiceRoot.v1_1_0.ServiceRoot","AccountService":{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},"Chassis":{"@odata.id":"/redfish/v1/Chassis"},"Description":"Root
-        Service","EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","JsonSchemas":{"@odata.id":"/redfish/v1/JSONSchemas"},"Links":{"Sessions":{"@odata.id":"/redfish/v1/Sessions"}},"Managers":{"@odata.id":"/redfish/v1/Managers"},"Name":"Root
-        Service","Oem":{"Dell":{"@odata.type":"/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot","IsBranded":0,"ManagerMACAddress":"10:98:36:a9:05:b0","ServiceTag":""}},"RedfishVersion":"1.0.2","Registries":{"@odata.id":"/redfish/v1/Registries"},"SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"Tasks":{"@odata.id":"/redfish/v1/TaskService"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}'
+      string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
+        Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
 - request:
     method: post
-    uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
     body:
       encoding: UTF-8
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
@@ -58,20 +57,20 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - 8cb5a132-59b9-47b2-a76f-6d4fea1c8cf7
+      - 696649b5-be3d-4c38-b164-82e84bfd0259
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:39 GMT
+      - Mon, 24 Sep 2018 13:48:07 GMT
       Content-Length:
-      - '238'
+      - '253'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Sessions/8cb5a132-59b9-47b2-a76f-6d4fea1c8cf7","Id":"8cb5a132-59b9-47b2-a76f-6d4fea1c8cf7","Name":"8cb5a132-59b9-47b2-a76f-6d4fea1c8cf7","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/696649b5-be3d-4c38-b164-82e84bfd0259","Id":"696649b5-be3d-4c38-b164-82e84bfd0259","Name":"696649b5-be3d-4c38-b164-82e84bfd0259","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -86,68 +85,16 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 8cb5a132-59b9-47b2-a76f-6d4fea1c8cf7
+      - 696649b5-be3d-4c38-b164-82e84bfd0259
   response:
     status:
-      code: 200
-      message: 'OK '
-    headers:
-      Server:
-      - Apache/2.4
-      Cache-Control:
-      - no-cache
-      X-Frame-Options:
-      - DENY
-      Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Allow:
-      - POST,PATCH
-      Access-Control-Allow-Origin:
-      - "*"
-      Date:
-      - Sat, 20 May 2017 09:58:17 GMT
-      Odata-Version:
-      - '4.0'
-      Link:
-      - "</redfish/v1/Schemas/ComputerSystem.v1_1_0.json>;rel=describedby"
-      Content-Length:
-      - '3515'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"SimpleStorage":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},"Links":{"CooledBy@odata.count":12,"PoweredBy@odata.count":0,"Oem":{"Dell":{"BootSources":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/BootSources"},"@odata.type":"#Dell.v1_0_0.BootSources"}},"ManagedBy":[{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1"}],"Chassis":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1"}],"Chassis@odata.count":1,"PoweredBy":[],"CooledBy":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],"ManagedBy@odata.count":1},"Processors":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors"},"@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","Manufacturer":"Dell Inc.","PowerState":"Off","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff","Name":"System","AssetTag":"","HostName":"","SerialNumber":"CN701636AB0013","@odata.type":"#ComputerSystem.v1_1_0.ComputerSystem","TrustedModules":[{"Status":{"State":"Disabled"}}],"IndicatorLED":"Off","SKU":"","MemorySummary":{"TotalSystemMemoryGiB":32.0,"Status":{"State":"Enabled","Health":null,"HealthRollup":null},"MemoryMirroring":"System"},"Model":"DSS9630M","@odata.id":"/redfish/v1/Systems/System.Embedded.1","Id":"System.Embedded.1","Bios":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Bios"},"SecureBoot":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/SecureBoot"},"ProcessorSummary":{"Status":{"State":"Enabled","Health":null,"HealthRollup":null},"Count":2,"Model":""},"SystemType":"Physical","@odata.context":"/redfish/v1/$metadata#ComputerSystem.ComputerSystem","PartNumber":"033RF3X04","BiosVersion":"0.4.8","EthernetInterfaces":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"},"Description":"Computer
-        System which represents a machine (physical or virtual) and the local resources
-        such as memory, cpu and other devices that can be accessed from that machine.","Actions":{"#ComputerSystem.Reset":{"target":"/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset","ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulRestart","GracefulShutdown","PushPowerButton","Nmi"]}},"Boot":{"UefiTargetBootSourceOverride":"","BootSourceOverrideTarget":"None","BootSourceOverrideTarget@Redfish.AllowableValues":["None","Pxe","Floppy","Cd","Hdd","BiosSetup","Utilities","UefiTarget","SDCard","UefiHttp"],"BootSourceOverrideEnabled":"Once","BootSourceOverrideMode":"UEFI"},"Status":{"State":"StandbyOffline","Health":"OK","HealthRollup":"OK"}}'
-    http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
-- request:
-    method: patch
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
-    body:
-      encoding: UTF-8
-      string: '{"IndicatorLED":"Blinking"}'
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - 8cb5a132-59b9-47b2-a76f-6d4fea1c8cf7
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 501
-      message: 'Not Implemented '
+      code: 404
+      message: 'Not Found '
     headers:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:39 GMT
+      - Mon, 24 Sep 2018 13:48:07 GMT
       Content-Length:
       - '0'
       Connection:
@@ -156,5 +103,36 @@ http_interactions:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
+- request:
+    method: delete
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/696649b5-be3d-4c38-b164-82e84bfd0259
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 696649b5-be3d-4c38-b164-82e84bfd0259
+  response:
+    status:
+      code: 204
+      message: 'No Content '
+    headers:
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:07 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_off/powers_off_the_system.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_off/powers_off_the_system.yml
@@ -23,21 +23,20 @@ http_interactions:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:38 GMT
+      - Mon, 24 Sep 2018 13:48:07 GMT
       Content-Length:
-      - '999'
+      - '362'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context":"/redfish/v1/$metadata#ServiceRoot.ServiceRoot","@odata.id":"/redfish/v1","@odata.type":"#ServiceRoot.v1_1_0.ServiceRoot","AccountService":{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},"Chassis":{"@odata.id":"/redfish/v1/Chassis"},"Description":"Root
-        Service","EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","JsonSchemas":{"@odata.id":"/redfish/v1/JSONSchemas"},"Links":{"Sessions":{"@odata.id":"/redfish/v1/Sessions"}},"Managers":{"@odata.id":"/redfish/v1/Managers"},"Name":"Root
-        Service","Oem":{"Dell":{"@odata.type":"/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot","IsBranded":0,"ManagerMACAddress":"10:98:36:a9:05:b0","ServiceTag":""}},"RedfishVersion":"1.0.2","Registries":{"@odata.id":"/redfish/v1/Registries"},"SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"Tasks":{"@odata.id":"/redfish/v1/TaskService"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}'
+      string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
+        Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:38 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
 - request:
     method: post
-    uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
     body:
       encoding: UTF-8
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
@@ -58,20 +57,20 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - a5b212d9-9529-444b-8f66-9d73a499b1df
+      - 8abdde5d-0194-45ab-9586-8f647a1d5e61
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:38 GMT
+      - Mon, 24 Sep 2018 13:48:07 GMT
       Content-Length:
-      - '238'
+      - '253'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Sessions/a5b212d9-9529-444b-8f66-9d73a499b1df","Id":"a5b212d9-9529-444b-8f66-9d73a499b1df","Name":"a5b212d9-9529-444b-8f66-9d73a499b1df","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/8abdde5d-0194-45ab-9586-8f647a1d5e61","Id":"8abdde5d-0194-45ab-9586-8f647a1d5e61","Name":"8abdde5d-0194-45ab-9586-8f647a1d5e61","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:38 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -86,59 +85,7 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - a5b212d9-9529-444b-8f66-9d73a499b1df
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Server:
-      - Apache/2.4
-      Cache-Control:
-      - no-cache
-      X-Frame-Options:
-      - DENY
-      Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Allow:
-      - POST,PATCH
-      Access-Control-Allow-Origin:
-      - "*"
-      Date:
-      - Sat, 20 May 2017 09:58:17 GMT
-      Odata-Version:
-      - '4.0'
-      Link:
-      - "</redfish/v1/Schemas/ComputerSystem.v1_1_0.json>;rel=describedby"
-      Content-Length:
-      - '3515'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"SimpleStorage":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},"Links":{"CooledBy@odata.count":12,"PoweredBy@odata.count":0,"Oem":{"Dell":{"BootSources":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/BootSources"},"@odata.type":"#Dell.v1_0_0.BootSources"}},"ManagedBy":[{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1"}],"Chassis":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1"}],"Chassis@odata.count":1,"PoweredBy":[],"CooledBy":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],"ManagedBy@odata.count":1},"Processors":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors"},"@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","Manufacturer":"Dell Inc.","PowerState":"Off","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff","Name":"System","AssetTag":"","HostName":"","SerialNumber":"CN701636AB0013","@odata.type":"#ComputerSystem.v1_1_0.ComputerSystem","TrustedModules":[{"Status":{"State":"Disabled"}}],"IndicatorLED":"Off","SKU":"","MemorySummary":{"TotalSystemMemoryGiB":32.0,"Status":{"State":"Enabled","Health":null,"HealthRollup":null},"MemoryMirroring":"System"},"Model":"DSS9630M","@odata.id":"/redfish/v1/Systems/System.Embedded.1","Id":"System.Embedded.1","Bios":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Bios"},"SecureBoot":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/SecureBoot"},"ProcessorSummary":{"Status":{"State":"Enabled","Health":null,"HealthRollup":null},"Count":2,"Model":""},"SystemType":"Physical","@odata.context":"/redfish/v1/$metadata#ComputerSystem.ComputerSystem","PartNumber":"033RF3X04","BiosVersion":"0.4.8","EthernetInterfaces":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"},"Description":"Computer
-        System which represents a machine (physical or virtual) and the local resources
-        such as memory, cpu and other devices that can be accessed from that machine.","Actions":{"#ComputerSystem.Reset":{"target":"/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset","ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulRestart","GracefulShutdown","PushPowerButton","Nmi"]}},"Boot":{"UefiTargetBootSourceOverride":"","BootSourceOverrideTarget":"None","BootSourceOverrideTarget@Redfish.AllowableValues":["None","Pxe","Floppy","Cd","Hdd","BiosSetup","Utilities","UefiTarget","SDCard","UefiHttp"],"BootSourceOverrideEnabled":"Once","BootSourceOverrideMode":"UEFI"},"Status":{"State":"StandbyOffline","Health":"OK","HealthRollup":"OK"}}'
-    http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
-- request:
-    method: post
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset
-    body:
-      encoding: UTF-8
-      string: '{"ResetType":"GracefulShutdown"}'
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - a5b212d9-9529-444b-8f66-9d73a499b1df
-      Content-Type:
-      - application/json
+      - 8abdde5d-0194-45ab-9586-8f647a1d5e61
   response:
     status:
       code: 404
@@ -147,7 +94,7 @@ http_interactions:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:39 GMT
+      - Mon, 24 Sep 2018 13:48:07 GMT
       Content-Length:
       - '0'
       Connection:
@@ -156,5 +103,36 @@ http_interactions:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
+- request:
+    method: delete
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/8abdde5d-0194-45ab-9586-8f647a1d5e61
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 8abdde5d-0194-45ab-9586-8f647a1d5e61
+  response:
+    status:
+      code: 204
+      message: 'No Content '
+    headers:
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:07 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_off_now/powers_off_the_system_immediately.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_off_now/powers_off_the_system_immediately.yml
@@ -23,21 +23,20 @@ http_interactions:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:38 GMT
+      - Mon, 24 Sep 2018 13:48:06 GMT
       Content-Length:
-      - '999'
+      - '362'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context":"/redfish/v1/$metadata#ServiceRoot.ServiceRoot","@odata.id":"/redfish/v1","@odata.type":"#ServiceRoot.v1_1_0.ServiceRoot","AccountService":{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},"Chassis":{"@odata.id":"/redfish/v1/Chassis"},"Description":"Root
-        Service","EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","JsonSchemas":{"@odata.id":"/redfish/v1/JSONSchemas"},"Links":{"Sessions":{"@odata.id":"/redfish/v1/Sessions"}},"Managers":{"@odata.id":"/redfish/v1/Managers"},"Name":"Root
-        Service","Oem":{"Dell":{"@odata.type":"/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot","IsBranded":0,"ManagerMACAddress":"10:98:36:a9:05:b0","ServiceTag":""}},"RedfishVersion":"1.0.2","Registries":{"@odata.id":"/redfish/v1/Registries"},"SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"Tasks":{"@odata.id":"/redfish/v1/TaskService"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}'
+      string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
+        Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:38 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
 - request:
     method: post
-    uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
     body:
       encoding: UTF-8
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
@@ -58,20 +57,20 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - 450f8785-e68c-4e82-9023-839add5c297b
+      - 4045fd45-1de3-41e2-a99d-550e87648bba
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:38 GMT
+      - Mon, 24 Sep 2018 13:48:06 GMT
       Content-Length:
-      - '238'
+      - '253'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Sessions/450f8785-e68c-4e82-9023-839add5c297b","Id":"450f8785-e68c-4e82-9023-839add5c297b","Name":"450f8785-e68c-4e82-9023-839add5c297b","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/4045fd45-1de3-41e2-a99d-550e87648bba","Id":"4045fd45-1de3-41e2-a99d-550e87648bba","Name":"4045fd45-1de3-41e2-a99d-550e87648bba","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:38 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -86,59 +85,7 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 450f8785-e68c-4e82-9023-839add5c297b
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Server:
-      - Apache/2.4
-      Cache-Control:
-      - no-cache
-      X-Frame-Options:
-      - DENY
-      Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Allow:
-      - POST,PATCH
-      Access-Control-Allow-Origin:
-      - "*"
-      Date:
-      - Sat, 20 May 2017 09:58:17 GMT
-      Odata-Version:
-      - '4.0'
-      Link:
-      - "</redfish/v1/Schemas/ComputerSystem.v1_1_0.json>;rel=describedby"
-      Content-Length:
-      - '3515'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"SimpleStorage":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},"Links":{"CooledBy@odata.count":12,"PoweredBy@odata.count":0,"Oem":{"Dell":{"BootSources":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/BootSources"},"@odata.type":"#Dell.v1_0_0.BootSources"}},"ManagedBy":[{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1"}],"Chassis":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1"}],"Chassis@odata.count":1,"PoweredBy":[],"CooledBy":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],"ManagedBy@odata.count":1},"Processors":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors"},"@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","Manufacturer":"Dell Inc.","PowerState":"Off","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff","Name":"System","AssetTag":"","HostName":"","SerialNumber":"CN701636AB0013","@odata.type":"#ComputerSystem.v1_1_0.ComputerSystem","TrustedModules":[{"Status":{"State":"Disabled"}}],"IndicatorLED":"Off","SKU":"","MemorySummary":{"TotalSystemMemoryGiB":32.0,"Status":{"State":"Enabled","Health":null,"HealthRollup":null},"MemoryMirroring":"System"},"Model":"DSS9630M","@odata.id":"/redfish/v1/Systems/System.Embedded.1","Id":"System.Embedded.1","Bios":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Bios"},"SecureBoot":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/SecureBoot"},"ProcessorSummary":{"Status":{"State":"Enabled","Health":null,"HealthRollup":null},"Count":2,"Model":""},"SystemType":"Physical","@odata.context":"/redfish/v1/$metadata#ComputerSystem.ComputerSystem","PartNumber":"033RF3X04","BiosVersion":"0.4.8","EthernetInterfaces":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"},"Description":"Computer
-        System which represents a machine (physical or virtual) and the local resources
-        such as memory, cpu and other devices that can be accessed from that machine.","Actions":{"#ComputerSystem.Reset":{"target":"/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset","ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulRestart","GracefulShutdown","PushPowerButton","Nmi"]}},"Boot":{"UefiTargetBootSourceOverride":"","BootSourceOverrideTarget":"None","BootSourceOverrideTarget@Redfish.AllowableValues":["None","Pxe","Floppy","Cd","Hdd","BiosSetup","Utilities","UefiTarget","SDCard","UefiHttp"],"BootSourceOverrideEnabled":"Once","BootSourceOverrideMode":"UEFI"},"Status":{"State":"StandbyOffline","Health":"OK","HealthRollup":"OK"}}'
-    http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:38 GMT
-- request:
-    method: post
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset
-    body:
-      encoding: UTF-8
-      string: '{"ResetType":"ForceOff"}'
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - 450f8785-e68c-4e82-9023-839add5c297b
-      Content-Type:
-      - application/json
+      - 4045fd45-1de3-41e2-a99d-550e87648bba
   response:
     status:
       code: 404
@@ -147,7 +94,7 @@ http_interactions:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:38 GMT
+      - Mon, 24 Sep 2018 13:48:06 GMT
       Content-Length:
       - '0'
       Connection:
@@ -156,5 +103,36 @@ http_interactions:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:38 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
+- request:
+    method: delete
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/4045fd45-1de3-41e2-a99d-550e87648bba
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 4045fd45-1de3-41e2-a99d-550e87648bba
+  response:
+    status:
+      code: 204
+      message: 'No Content '
+    headers:
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:06 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_on/powers_on_the_system.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_on/powers_on_the_system.yml
@@ -23,21 +23,20 @@ http_interactions:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:39 GMT
+      - Mon, 24 Sep 2018 13:48:07 GMT
       Content-Length:
-      - '999'
+      - '362'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context":"/redfish/v1/$metadata#ServiceRoot.ServiceRoot","@odata.id":"/redfish/v1","@odata.type":"#ServiceRoot.v1_1_0.ServiceRoot","AccountService":{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},"Chassis":{"@odata.id":"/redfish/v1/Chassis"},"Description":"Root
-        Service","EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","JsonSchemas":{"@odata.id":"/redfish/v1/JSONSchemas"},"Links":{"Sessions":{"@odata.id":"/redfish/v1/Sessions"}},"Managers":{"@odata.id":"/redfish/v1/Managers"},"Name":"Root
-        Service","Oem":{"Dell":{"@odata.type":"/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot","IsBranded":0,"ManagerMACAddress":"10:98:36:a9:05:b0","ServiceTag":""}},"RedfishVersion":"1.0.2","Registries":{"@odata.id":"/redfish/v1/Registries"},"SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"Tasks":{"@odata.id":"/redfish/v1/TaskService"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}'
+      string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
+        Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
 - request:
     method: post
-    uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
     body:
       encoding: UTF-8
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
@@ -58,20 +57,20 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - 7cc3a568-6e66-404f-a4cb-40d67ff8f8a3
+      - 61685e47-56a5-4ec8-b543-b73bfdcfc13b
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:39 GMT
+      - Mon, 24 Sep 2018 13:48:07 GMT
       Content-Length:
-      - '238'
+      - '253'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Sessions/7cc3a568-6e66-404f-a4cb-40d67ff8f8a3","Id":"7cc3a568-6e66-404f-a4cb-40d67ff8f8a3","Name":"7cc3a568-6e66-404f-a4cb-40d67ff8f8a3","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/61685e47-56a5-4ec8-b543-b73bfdcfc13b","Id":"61685e47-56a5-4ec8-b543-b73bfdcfc13b","Name":"61685e47-56a5-4ec8-b543-b73bfdcfc13b","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -86,59 +85,7 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 7cc3a568-6e66-404f-a4cb-40d67ff8f8a3
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Server:
-      - Apache/2.4
-      Cache-Control:
-      - no-cache
-      X-Frame-Options:
-      - DENY
-      Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Allow:
-      - POST,PATCH
-      Access-Control-Allow-Origin:
-      - "*"
-      Date:
-      - Sat, 20 May 2017 09:58:17 GMT
-      Odata-Version:
-      - '4.0'
-      Link:
-      - "</redfish/v1/Schemas/ComputerSystem.v1_1_0.json>;rel=describedby"
-      Content-Length:
-      - '3515'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"SimpleStorage":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},"Links":{"CooledBy@odata.count":12,"PoweredBy@odata.count":0,"Oem":{"Dell":{"BootSources":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/BootSources"},"@odata.type":"#Dell.v1_0_0.BootSources"}},"ManagedBy":[{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1"}],"Chassis":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1"}],"Chassis@odata.count":1,"PoweredBy":[],"CooledBy":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],"ManagedBy@odata.count":1},"Processors":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors"},"@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","Manufacturer":"Dell Inc.","PowerState":"Off","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff","Name":"System","AssetTag":"","HostName":"","SerialNumber":"CN701636AB0013","@odata.type":"#ComputerSystem.v1_1_0.ComputerSystem","TrustedModules":[{"Status":{"State":"Disabled"}}],"IndicatorLED":"Off","SKU":"","MemorySummary":{"TotalSystemMemoryGiB":32.0,"Status":{"State":"Enabled","Health":null,"HealthRollup":null},"MemoryMirroring":"System"},"Model":"DSS9630M","@odata.id":"/redfish/v1/Systems/System.Embedded.1","Id":"System.Embedded.1","Bios":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Bios"},"SecureBoot":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/SecureBoot"},"ProcessorSummary":{"Status":{"State":"Enabled","Health":null,"HealthRollup":null},"Count":2,"Model":""},"SystemType":"Physical","@odata.context":"/redfish/v1/$metadata#ComputerSystem.ComputerSystem","PartNumber":"033RF3X04","BiosVersion":"0.4.8","EthernetInterfaces":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"},"Description":"Computer
-        System which represents a machine (physical or virtual) and the local resources
-        such as memory, cpu and other devices that can be accessed from that machine.","Actions":{"#ComputerSystem.Reset":{"target":"/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset","ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulRestart","GracefulShutdown","PushPowerButton","Nmi"]}},"Boot":{"UefiTargetBootSourceOverride":"","BootSourceOverrideTarget":"None","BootSourceOverrideTarget@Redfish.AllowableValues":["None","Pxe","Floppy","Cd","Hdd","BiosSetup","Utilities","UefiTarget","SDCard","UefiHttp"],"BootSourceOverrideEnabled":"Once","BootSourceOverrideMode":"UEFI"},"Status":{"State":"StandbyOffline","Health":"OK","HealthRollup":"OK"}}'
-    http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
-- request:
-    method: post
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset
-    body:
-      encoding: UTF-8
-      string: '{"ResetType":"On"}'
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - 7cc3a568-6e66-404f-a4cb-40d67ff8f8a3
-      Content-Type:
-      - application/json
+      - 61685e47-56a5-4ec8-b543-b73bfdcfc13b
   response:
     status:
       code: 404
@@ -147,7 +94,7 @@ http_interactions:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:39 GMT
+      - Mon, 24 Sep 2018 13:48:07 GMT
       Content-Length:
       - '0'
       Connection:
@@ -156,5 +103,36 @@ http_interactions:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
+- request:
+    method: delete
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/61685e47-56a5-4ec8-b543-b73bfdcfc13b
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 61685e47-56a5-4ec8-b543-b73bfdcfc13b
+  response:
+    status:
+      code: 204
+      message: 'No Content '
+    headers:
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:07 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_restart/restarts_the_system.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_restart/restarts_the_system.yml
@@ -23,21 +23,20 @@ http_interactions:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:38 GMT
+      - Mon, 24 Sep 2018 13:48:07 GMT
       Content-Length:
-      - '999'
+      - '362'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context":"/redfish/v1/$metadata#ServiceRoot.ServiceRoot","@odata.id":"/redfish/v1","@odata.type":"#ServiceRoot.v1_1_0.ServiceRoot","AccountService":{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},"Chassis":{"@odata.id":"/redfish/v1/Chassis"},"Description":"Root
-        Service","EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","JsonSchemas":{"@odata.id":"/redfish/v1/JSONSchemas"},"Links":{"Sessions":{"@odata.id":"/redfish/v1/Sessions"}},"Managers":{"@odata.id":"/redfish/v1/Managers"},"Name":"Root
-        Service","Oem":{"Dell":{"@odata.type":"/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot","IsBranded":0,"ManagerMACAddress":"10:98:36:a9:05:b0","ServiceTag":""}},"RedfishVersion":"1.0.2","Registries":{"@odata.id":"/redfish/v1/Registries"},"SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"Tasks":{"@odata.id":"/redfish/v1/TaskService"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}'
+      string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
+        Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:38 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
 - request:
     method: post
-    uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
     body:
       encoding: UTF-8
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
@@ -58,20 +57,20 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - 1a323b17-3ad1-4ef9-a79d-126b8ff28ca9
+      - 41e251fb-ad8c-4959-b67d-3d9ad5e61b29
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:38 GMT
+      - Mon, 24 Sep 2018 13:48:07 GMT
       Content-Length:
-      - '238'
+      - '253'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Sessions/1a323b17-3ad1-4ef9-a79d-126b8ff28ca9","Id":"1a323b17-3ad1-4ef9-a79d-126b8ff28ca9","Name":"1a323b17-3ad1-4ef9-a79d-126b8ff28ca9","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/41e251fb-ad8c-4959-b67d-3d9ad5e61b29","Id":"41e251fb-ad8c-4959-b67d-3d9ad5e61b29","Name":"41e251fb-ad8c-4959-b67d-3d9ad5e61b29","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:38 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -86,59 +85,7 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 1a323b17-3ad1-4ef9-a79d-126b8ff28ca9
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Server:
-      - Apache/2.4
-      Cache-Control:
-      - no-cache
-      X-Frame-Options:
-      - DENY
-      Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Allow:
-      - POST,PATCH
-      Access-Control-Allow-Origin:
-      - "*"
-      Date:
-      - Sat, 20 May 2017 09:58:17 GMT
-      Odata-Version:
-      - '4.0'
-      Link:
-      - "</redfish/v1/Schemas/ComputerSystem.v1_1_0.json>;rel=describedby"
-      Content-Length:
-      - '3515'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"SimpleStorage":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},"Links":{"CooledBy@odata.count":12,"PoweredBy@odata.count":0,"Oem":{"Dell":{"BootSources":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/BootSources"},"@odata.type":"#Dell.v1_0_0.BootSources"}},"ManagedBy":[{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1"}],"Chassis":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1"}],"Chassis@odata.count":1,"PoweredBy":[],"CooledBy":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],"ManagedBy@odata.count":1},"Processors":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors"},"@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","Manufacturer":"Dell Inc.","PowerState":"Off","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff","Name":"System","AssetTag":"","HostName":"","SerialNumber":"CN701636AB0013","@odata.type":"#ComputerSystem.v1_1_0.ComputerSystem","TrustedModules":[{"Status":{"State":"Disabled"}}],"IndicatorLED":"Off","SKU":"","MemorySummary":{"TotalSystemMemoryGiB":32.0,"Status":{"State":"Enabled","Health":null,"HealthRollup":null},"MemoryMirroring":"System"},"Model":"DSS9630M","@odata.id":"/redfish/v1/Systems/System.Embedded.1","Id":"System.Embedded.1","Bios":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Bios"},"SecureBoot":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/SecureBoot"},"ProcessorSummary":{"Status":{"State":"Enabled","Health":null,"HealthRollup":null},"Count":2,"Model":""},"SystemType":"Physical","@odata.context":"/redfish/v1/$metadata#ComputerSystem.ComputerSystem","PartNumber":"033RF3X04","BiosVersion":"0.4.8","EthernetInterfaces":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"},"Description":"Computer
-        System which represents a machine (physical or virtual) and the local resources
-        such as memory, cpu and other devices that can be accessed from that machine.","Actions":{"#ComputerSystem.Reset":{"target":"/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset","ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulRestart","GracefulShutdown","PushPowerButton","Nmi"]}},"Boot":{"UefiTargetBootSourceOverride":"","BootSourceOverrideTarget":"None","BootSourceOverrideTarget@Redfish.AllowableValues":["None","Pxe","Floppy","Cd","Hdd","BiosSetup","Utilities","UefiTarget","SDCard","UefiHttp"],"BootSourceOverrideEnabled":"Once","BootSourceOverrideMode":"UEFI"},"Status":{"State":"StandbyOffline","Health":"OK","HealthRollup":"OK"}}'
-    http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:38 GMT
-- request:
-    method: post
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset
-    body:
-      encoding: UTF-8
-      string: '{"ResetType":"GracefulRestart"}'
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - 1a323b17-3ad1-4ef9-a79d-126b8ff28ca9
-      Content-Type:
-      - application/json
+      - 41e251fb-ad8c-4959-b67d-3d9ad5e61b29
   response:
     status:
       code: 404
@@ -147,7 +94,7 @@ http_interactions:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:38 GMT
+      - Mon, 24 Sep 2018 13:48:07 GMT
       Content-Length:
       - '0'
       Connection:
@@ -156,5 +103,36 @@ http_interactions:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:38 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
+- request:
+    method: delete
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/41e251fb-ad8c-4959-b67d-3d9ad5e61b29
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 41e251fb-ad8c-4959-b67d-3d9ad5e61b29
+  response:
+    status:
+      code: 204
+      message: 'No Content '
+    headers:
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:07 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_restart_now/restarts_the_system_immediately.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_restart_now/restarts_the_system_immediately.yml
@@ -23,21 +23,20 @@ http_interactions:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:38 GMT
+      - Mon, 24 Sep 2018 13:48:06 GMT
       Content-Length:
-      - '999'
+      - '362'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context":"/redfish/v1/$metadata#ServiceRoot.ServiceRoot","@odata.id":"/redfish/v1","@odata.type":"#ServiceRoot.v1_1_0.ServiceRoot","AccountService":{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},"Chassis":{"@odata.id":"/redfish/v1/Chassis"},"Description":"Root
-        Service","EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","JsonSchemas":{"@odata.id":"/redfish/v1/JSONSchemas"},"Links":{"Sessions":{"@odata.id":"/redfish/v1/Sessions"}},"Managers":{"@odata.id":"/redfish/v1/Managers"},"Name":"Root
-        Service","Oem":{"Dell":{"@odata.type":"/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot","IsBranded":0,"ManagerMACAddress":"10:98:36:a9:05:b0","ServiceTag":""}},"RedfishVersion":"1.0.2","Registries":{"@odata.id":"/redfish/v1/Registries"},"SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"Tasks":{"@odata.id":"/redfish/v1/TaskService"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}'
+      string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
+        Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:38 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
 - request:
     method: post
-    uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
     body:
       encoding: UTF-8
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
@@ -58,20 +57,20 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - f4feab54-6bc0-4cdc-a1e5-a71307f6000a
+      - '09b766d7-ce2a-427c-8891-cea2a27f24ca'
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:38 GMT
+      - Mon, 24 Sep 2018 13:48:06 GMT
       Content-Length:
-      - '238'
+      - '253'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Sessions/f4feab54-6bc0-4cdc-a1e5-a71307f6000a","Id":"f4feab54-6bc0-4cdc-a1e5-a71307f6000a","Name":"f4feab54-6bc0-4cdc-a1e5-a71307f6000a","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/09b766d7-ce2a-427c-8891-cea2a27f24ca","Id":"09b766d7-ce2a-427c-8891-cea2a27f24ca","Name":"09b766d7-ce2a-427c-8891-cea2a27f24ca","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:38 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -86,59 +85,7 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - f4feab54-6bc0-4cdc-a1e5-a71307f6000a
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Server:
-      - Apache/2.4
-      Cache-Control:
-      - no-cache
-      X-Frame-Options:
-      - DENY
-      Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Allow:
-      - POST,PATCH
-      Access-Control-Allow-Origin:
-      - "*"
-      Date:
-      - Sat, 20 May 2017 09:58:17 GMT
-      Odata-Version:
-      - '4.0'
-      Link:
-      - "</redfish/v1/Schemas/ComputerSystem.v1_1_0.json>;rel=describedby"
-      Content-Length:
-      - '3515'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"SimpleStorage":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},"Links":{"CooledBy@odata.count":12,"PoweredBy@odata.count":0,"Oem":{"Dell":{"BootSources":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/BootSources"},"@odata.type":"#Dell.v1_0_0.BootSources"}},"ManagedBy":[{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1"}],"Chassis":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1"}],"Chassis@odata.count":1,"PoweredBy":[],"CooledBy":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],"ManagedBy@odata.count":1},"Processors":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors"},"@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","Manufacturer":"Dell Inc.","PowerState":"Off","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff","Name":"System","AssetTag":"","HostName":"","SerialNumber":"CN701636AB0013","@odata.type":"#ComputerSystem.v1_1_0.ComputerSystem","TrustedModules":[{"Status":{"State":"Disabled"}}],"IndicatorLED":"Off","SKU":"","MemorySummary":{"TotalSystemMemoryGiB":32.0,"Status":{"State":"Enabled","Health":null,"HealthRollup":null},"MemoryMirroring":"System"},"Model":"DSS9630M","@odata.id":"/redfish/v1/Systems/System.Embedded.1","Id":"System.Embedded.1","Bios":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Bios"},"SecureBoot":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/SecureBoot"},"ProcessorSummary":{"Status":{"State":"Enabled","Health":null,"HealthRollup":null},"Count":2,"Model":""},"SystemType":"Physical","@odata.context":"/redfish/v1/$metadata#ComputerSystem.ComputerSystem","PartNumber":"033RF3X04","BiosVersion":"0.4.8","EthernetInterfaces":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"},"Description":"Computer
-        System which represents a machine (physical or virtual) and the local resources
-        such as memory, cpu and other devices that can be accessed from that machine.","Actions":{"#ComputerSystem.Reset":{"target":"/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset","ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulRestart","GracefulShutdown","PushPowerButton","Nmi"]}},"Boot":{"UefiTargetBootSourceOverride":"","BootSourceOverrideTarget":"None","BootSourceOverrideTarget@Redfish.AllowableValues":["None","Pxe","Floppy","Cd","Hdd","BiosSetup","Utilities","UefiTarget","SDCard","UefiHttp"],"BootSourceOverrideEnabled":"Once","BootSourceOverrideMode":"UEFI"},"Status":{"State":"StandbyOffline","Health":"OK","HealthRollup":"OK"}}'
-    http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:38 GMT
-- request:
-    method: post
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset
-    body:
-      encoding: UTF-8
-      string: '{"ResetType":"ForceRestart"}'
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - f4feab54-6bc0-4cdc-a1e5-a71307f6000a
-      Content-Type:
-      - application/json
+      - '09b766d7-ce2a-427c-8891-cea2a27f24ca'
   response:
     status:
       code: 404
@@ -147,7 +94,7 @@ http_interactions:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:38 GMT
+      - Mon, 24 Sep 2018 13:48:06 GMT
       Content-Length:
       - '0'
       Connection:
@@ -156,5 +103,36 @@ http_interactions:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:38 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
+- request:
+    method: delete
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/09b766d7-ce2a-427c-8891-cea2a27f24ca
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - '09b766d7-ce2a-427c-8891-cea2a27f24ca'
+  response:
+    status:
+      code: 204
+      message: 'No Content '
+    headers:
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:06 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_turn_off_loc_led/turns_off_location_LED.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_turn_off_loc_led/turns_off_location_LED.yml
@@ -23,21 +23,20 @@ http_interactions:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:39 GMT
+      - Mon, 24 Sep 2018 13:48:07 GMT
       Content-Length:
-      - '999'
+      - '362'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context":"/redfish/v1/$metadata#ServiceRoot.ServiceRoot","@odata.id":"/redfish/v1","@odata.type":"#ServiceRoot.v1_1_0.ServiceRoot","AccountService":{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},"Chassis":{"@odata.id":"/redfish/v1/Chassis"},"Description":"Root
-        Service","EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","JsonSchemas":{"@odata.id":"/redfish/v1/JSONSchemas"},"Links":{"Sessions":{"@odata.id":"/redfish/v1/Sessions"}},"Managers":{"@odata.id":"/redfish/v1/Managers"},"Name":"Root
-        Service","Oem":{"Dell":{"@odata.type":"/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot","IsBranded":0,"ManagerMACAddress":"10:98:36:a9:05:b0","ServiceTag":""}},"RedfishVersion":"1.0.2","Registries":{"@odata.id":"/redfish/v1/Registries"},"SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"Tasks":{"@odata.id":"/redfish/v1/TaskService"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}'
+      string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
+        Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
 - request:
     method: post
-    uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
     body:
       encoding: UTF-8
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
@@ -58,20 +57,20 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - b8ed5593-42ee-4a65-a437-c8942fd5ea56
+      - a5ad74fe-2149-4dc3-b2c9-60f3591e2502
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:39 GMT
+      - Mon, 24 Sep 2018 13:48:07 GMT
       Content-Length:
-      - '238'
+      - '253'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Sessions/b8ed5593-42ee-4a65-a437-c8942fd5ea56","Id":"b8ed5593-42ee-4a65-a437-c8942fd5ea56","Name":"b8ed5593-42ee-4a65-a437-c8942fd5ea56","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/a5ad74fe-2149-4dc3-b2c9-60f3591e2502","Id":"a5ad74fe-2149-4dc3-b2c9-60f3591e2502","Name":"a5ad74fe-2149-4dc3-b2c9-60f3591e2502","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -86,68 +85,16 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - b8ed5593-42ee-4a65-a437-c8942fd5ea56
+      - a5ad74fe-2149-4dc3-b2c9-60f3591e2502
   response:
     status:
-      code: 200
-      message: 'OK '
-    headers:
-      Server:
-      - Apache/2.4
-      Cache-Control:
-      - no-cache
-      X-Frame-Options:
-      - DENY
-      Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Allow:
-      - POST,PATCH
-      Access-Control-Allow-Origin:
-      - "*"
-      Date:
-      - Sat, 20 May 2017 09:58:17 GMT
-      Odata-Version:
-      - '4.0'
-      Link:
-      - "</redfish/v1/Schemas/ComputerSystem.v1_1_0.json>;rel=describedby"
-      Content-Length:
-      - '3515'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"SimpleStorage":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},"Links":{"CooledBy@odata.count":12,"PoweredBy@odata.count":0,"Oem":{"Dell":{"BootSources":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/BootSources"},"@odata.type":"#Dell.v1_0_0.BootSources"}},"ManagedBy":[{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1"}],"Chassis":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1"}],"Chassis@odata.count":1,"PoweredBy":[],"CooledBy":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],"ManagedBy@odata.count":1},"Processors":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors"},"@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","Manufacturer":"Dell Inc.","PowerState":"Off","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff","Name":"System","AssetTag":"","HostName":"","SerialNumber":"CN701636AB0013","@odata.type":"#ComputerSystem.v1_1_0.ComputerSystem","TrustedModules":[{"Status":{"State":"Disabled"}}],"IndicatorLED":"Off","SKU":"","MemorySummary":{"TotalSystemMemoryGiB":32.0,"Status":{"State":"Enabled","Health":null,"HealthRollup":null},"MemoryMirroring":"System"},"Model":"DSS9630M","@odata.id":"/redfish/v1/Systems/System.Embedded.1","Id":"System.Embedded.1","Bios":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Bios"},"SecureBoot":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/SecureBoot"},"ProcessorSummary":{"Status":{"State":"Enabled","Health":null,"HealthRollup":null},"Count":2,"Model":""},"SystemType":"Physical","@odata.context":"/redfish/v1/$metadata#ComputerSystem.ComputerSystem","PartNumber":"033RF3X04","BiosVersion":"0.4.8","EthernetInterfaces":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"},"Description":"Computer
-        System which represents a machine (physical or virtual) and the local resources
-        such as memory, cpu and other devices that can be accessed from that machine.","Actions":{"#ComputerSystem.Reset":{"target":"/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset","ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulRestart","GracefulShutdown","PushPowerButton","Nmi"]}},"Boot":{"UefiTargetBootSourceOverride":"","BootSourceOverrideTarget":"None","BootSourceOverrideTarget@Redfish.AllowableValues":["None","Pxe","Floppy","Cd","Hdd","BiosSetup","Utilities","UefiTarget","SDCard","UefiHttp"],"BootSourceOverrideEnabled":"Once","BootSourceOverrideMode":"UEFI"},"Status":{"State":"StandbyOffline","Health":"OK","HealthRollup":"OK"}}'
-    http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
-- request:
-    method: patch
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
-    body:
-      encoding: UTF-8
-      string: '{"IndicatorLED":"Off"}'
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - b8ed5593-42ee-4a65-a437-c8942fd5ea56
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 501
-      message: 'Not Implemented '
+      code: 404
+      message: 'Not Found '
     headers:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:39 GMT
+      - Mon, 24 Sep 2018 13:48:07 GMT
       Content-Length:
       - '0'
       Connection:
@@ -156,5 +103,36 @@ http_interactions:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
+- request:
+    method: delete
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/a5ad74fe-2149-4dc3-b2c9-60f3591e2502
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - a5ad74fe-2149-4dc3-b2c9-60f3591e2502
+  response:
+    status:
+      code: 204
+      message: 'No Content '
+    headers:
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:07 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_turn_on_loc_led/turns_on_location_LED.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_turn_on_loc_led/turns_on_location_LED.yml
@@ -23,21 +23,20 @@ http_interactions:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:39 GMT
+      - Mon, 24 Sep 2018 13:48:07 GMT
       Content-Length:
-      - '999'
+      - '362'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context":"/redfish/v1/$metadata#ServiceRoot.ServiceRoot","@odata.id":"/redfish/v1","@odata.type":"#ServiceRoot.v1_1_0.ServiceRoot","AccountService":{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},"Chassis":{"@odata.id":"/redfish/v1/Chassis"},"Description":"Root
-        Service","EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","JsonSchemas":{"@odata.id":"/redfish/v1/JSONSchemas"},"Links":{"Sessions":{"@odata.id":"/redfish/v1/Sessions"}},"Managers":{"@odata.id":"/redfish/v1/Managers"},"Name":"Root
-        Service","Oem":{"Dell":{"@odata.type":"/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot","IsBranded":0,"ManagerMACAddress":"10:98:36:a9:05:b0","ServiceTag":""}},"RedfishVersion":"1.0.2","Registries":{"@odata.id":"/redfish/v1/Registries"},"SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"Tasks":{"@odata.id":"/redfish/v1/TaskService"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}'
+      string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
+        Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
 - request:
     method: post
-    uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
     body:
       encoding: UTF-8
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
@@ -58,20 +57,20 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - 58379189-9c07-42ca-8046-aca31c2d0bff
+      - 0d31712f-a566-43b4-909f-80aae0fc980c
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:39 GMT
+      - Mon, 24 Sep 2018 13:48:07 GMT
       Content-Length:
-      - '238'
+      - '253'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Sessions/58379189-9c07-42ca-8046-aca31c2d0bff","Id":"58379189-9c07-42ca-8046-aca31c2d0bff","Name":"58379189-9c07-42ca-8046-aca31c2d0bff","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/0d31712f-a566-43b4-909f-80aae0fc980c","Id":"0d31712f-a566-43b4-909f-80aae0fc980c","Name":"0d31712f-a566-43b4-909f-80aae0fc980c","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
@@ -86,68 +85,16 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 58379189-9c07-42ca-8046-aca31c2d0bff
+      - 0d31712f-a566-43b4-909f-80aae0fc980c
   response:
     status:
-      code: 200
-      message: 'OK '
-    headers:
-      Server:
-      - Apache/2.4
-      Cache-Control:
-      - no-cache
-      X-Frame-Options:
-      - DENY
-      Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Allow:
-      - POST,PATCH
-      Access-Control-Allow-Origin:
-      - "*"
-      Date:
-      - Sat, 20 May 2017 09:58:17 GMT
-      Odata-Version:
-      - '4.0'
-      Link:
-      - "</redfish/v1/Schemas/ComputerSystem.v1_1_0.json>;rel=describedby"
-      Content-Length:
-      - '3515'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"SimpleStorage":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},"Links":{"CooledBy@odata.count":12,"PoweredBy@odata.count":0,"Oem":{"Dell":{"BootSources":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/BootSources"},"@odata.type":"#Dell.v1_0_0.BootSources"}},"ManagedBy":[{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1"}],"Chassis":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1"}],"Chassis@odata.count":1,"PoweredBy":[],"CooledBy":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],"ManagedBy@odata.count":1},"Processors":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors"},"@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","Manufacturer":"Dell Inc.","PowerState":"Off","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff","Name":"System","AssetTag":"","HostName":"","SerialNumber":"CN701636AB0013","@odata.type":"#ComputerSystem.v1_1_0.ComputerSystem","TrustedModules":[{"Status":{"State":"Disabled"}}],"IndicatorLED":"Off","SKU":"","MemorySummary":{"TotalSystemMemoryGiB":32.0,"Status":{"State":"Enabled","Health":null,"HealthRollup":null},"MemoryMirroring":"System"},"Model":"DSS9630M","@odata.id":"/redfish/v1/Systems/System.Embedded.1","Id":"System.Embedded.1","Bios":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Bios"},"SecureBoot":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/SecureBoot"},"ProcessorSummary":{"Status":{"State":"Enabled","Health":null,"HealthRollup":null},"Count":2,"Model":""},"SystemType":"Physical","@odata.context":"/redfish/v1/$metadata#ComputerSystem.ComputerSystem","PartNumber":"033RF3X04","BiosVersion":"0.4.8","EthernetInterfaces":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"},"Description":"Computer
-        System which represents a machine (physical or virtual) and the local resources
-        such as memory, cpu and other devices that can be accessed from that machine.","Actions":{"#ComputerSystem.Reset":{"target":"/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset","ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulRestart","GracefulShutdown","PushPowerButton","Nmi"]}},"Boot":{"UefiTargetBootSourceOverride":"","BootSourceOverrideTarget":"None","BootSourceOverrideTarget@Redfish.AllowableValues":["None","Pxe","Floppy","Cd","Hdd","BiosSetup","Utilities","UefiTarget","SDCard","UefiHttp"],"BootSourceOverrideEnabled":"Once","BootSourceOverrideMode":"UEFI"},"Status":{"State":"StandbyOffline","Health":"OK","HealthRollup":"OK"}}'
-    http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
-- request:
-    method: patch
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
-    body:
-      encoding: UTF-8
-      string: '{"IndicatorLED":"Lit"}'
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - 58379189-9c07-42ca-8046-aca31c2d0bff
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 501
-      message: 'Not Implemented '
+      code: 404
+      message: 'Not Found '
     headers:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:39 GMT
+      - Mon, 24 Sep 2018 13:48:07 GMT
       Content-Length:
       - '0'
       Connection:
@@ -156,5 +103,36 @@ http_interactions:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
+- request:
+    method: delete
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/0d31712f-a566-43b4-909f-80aae0fc980c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 0d31712f-a566-43b4-909f-80aae0fc980c
+  response:
+    status:
+      code: 204
+      message: 'No Content '
+    headers:
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:07 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:07 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager_Refresher/refresh/will_perform_a_full_refresh.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager_Refresher/refresh/will_perform_a_full_refresh.yml
@@ -23,21 +23,20 @@ http_interactions:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:39 GMT
+      - Mon, 24 Sep 2018 13:48:02 GMT
       Content-Length:
-      - '999'
+      - '362'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context":"/redfish/v1/$metadata#ServiceRoot.ServiceRoot","@odata.id":"/redfish/v1","@odata.type":"#ServiceRoot.v1_1_0.ServiceRoot","AccountService":{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},"Chassis":{"@odata.id":"/redfish/v1/Chassis"},"Description":"Root
-        Service","EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","JsonSchemas":{"@odata.id":"/redfish/v1/JSONSchemas"},"Links":{"Sessions":{"@odata.id":"/redfish/v1/Sessions"}},"Managers":{"@odata.id":"/redfish/v1/Managers"},"Name":"Root
-        Service","Oem":{"Dell":{"@odata.type":"/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot","IsBranded":0,"ManagerMACAddress":"10:98:36:a9:05:b0","ServiceTag":""}},"RedfishVersion":"1.0.2","Registries":{"@odata.id":"/redfish/v1/Registries"},"SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"Tasks":{"@odata.id":"/redfish/v1/TaskService"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}'
+      string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
+        Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:02 GMT
 - request:
     method: post
-    uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
     body:
       encoding: UTF-8
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
@@ -58,20 +57,20 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - 76c5d669-2cc3-49f9-9511-9419f16ecc1f
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:39 GMT
+      - Mon, 24 Sep 2018 13:48:02 GMT
       Content-Length:
-      - '238'
+      - '253'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Sessions/76c5d669-2cc3-49f9-9511-9419f16ecc1f","Id":"76c5d669-2cc3-49f9-9511-9419f16ecc1f","Name":"76c5d669-2cc3-49f9-9511-9419f16ecc1f","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/b2ef62d6-f45d-4316-912a-dfefddf4e2c9","Id":"b2ef62d6-f45d-4316-912a-dfefddf4e2c9","Name":"b2ef62d6-f45d-4316-912a-dfefddf4e2c9","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:02 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems
@@ -86,42 +85,31 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 76c5d669-2cc3-49f9-9511-9419f16ecc1f
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
   response:
     status:
       code: 200
       message: 'OK '
     headers:
-      Server:
-      - Apache/2.4
-      Date:
-      - Sat, 20 May 2017 09:58:16 GMT
-      Odata-Version:
-      - '4.0'
-      X-Frame-Options:
-      - DENY
       Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Link:
-      - "</redfish/v1/Schemas/ComputerSystemCollection.json>;rel=describedby"
-      Cache-Control:
-      - no-cache
-      Access-Control-Allow-Origin:
-      - "*"
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:02 GMT
       Content-Length:
-      - '438'
+      - '260'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems","@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","@odata.type":"#ComputerSystemCollection.ComputerSystemCollection","Description":"Collection
-        of Computer Systems","Members@odata.count":1,"Name":"Computer System Collection","Members":[{"@odata.id":"/redfish/v1/Systems/System.Embedded.1"}],"@odata.context":"/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection"}'
+      string: '{"@odata.id":"/redfish/v1/Systems","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2"},{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1"}],"Members@odata.count":3,"Name":"Computer
+        System Collection"}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:39 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:02 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
     body:
       encoding: US-ASCII
       string: ''
@@ -133,45 +121,32 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 76c5d669-2cc3-49f9-9511-9419f16ecc1f
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
   response:
     status:
       code: 200
       message: 'OK '
     headers:
-      Server:
-      - Apache/2.4
-      Cache-Control:
-      - no-cache
-      X-Frame-Options:
-      - DENY
       Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Allow:
-      - POST,PATCH
-      Access-Control-Allow-Origin:
-      - "*"
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Sat, 20 May 2017 09:58:17 GMT
-      Odata-Version:
-      - '4.0'
-      Link:
-      - "</redfish/v1/Schemas/ComputerSystem.v1_1_0.json>;rel=describedby"
+      - Mon, 24 Sep 2018 13:48:02 GMT
       Content-Length:
-      - '3515'
+      - '984'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"SimpleStorage":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},"Links":{"CooledBy@odata.count":12,"PoweredBy@odata.count":0,"Oem":{"Dell":{"BootSources":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/BootSources"},"@odata.type":"#Dell.v1_0_0.BootSources"}},"ManagedBy":[{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1"}],"Chassis":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1"}],"Chassis@odata.count":1,"PoweredBy":[],"CooledBy":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],"ManagedBy@odata.count":1},"Processors":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors"},"@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","Manufacturer":"Dell Inc.","PowerState":"Off","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff","Name":"System","AssetTag":"","HostName":"","SerialNumber":"CN701636AB0013","@odata.type":"#ComputerSystem.v1_1_0.ComputerSystem","TrustedModules":[{"Status":{"State":"Disabled"}}],"IndicatorLED":"Off","SKU":"","MemorySummary":{"TotalSystemMemoryGiB":32.0,"Status":{"State":"Enabled","Health":null,"HealthRollup":null},"MemoryMirroring":"System"},"Model":"DSS9630M","@odata.id":"/redfish/v1/Systems/System.Embedded.1","Id":"System.Embedded.1","Bios":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Bios"},"SecureBoot":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/SecureBoot"},"ProcessorSummary":{"Status":{"State":"Enabled","Health":null,"HealthRollup":null},"Count":2,"Model":""},"SystemType":"Physical","@odata.context":"/redfish/v1/$metadata#ComputerSystem.ComputerSystem","PartNumber":"033RF3X04","BiosVersion":"0.4.8","EthernetInterfaces":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"},"Description":"Computer
-        System which represents a machine (physical or virtual) and the local resources
-        such as memory, cpu and other devices that can be accessed from that machine.","Actions":{"#ComputerSystem.Reset":{"target":"/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset","ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulRestart","GracefulShutdown","PushPowerButton","Nmi"]}},"Boot":{"UefiTargetBootSourceOverride":"","BootSourceOverrideTarget":"None","BootSourceOverrideTarget@Redfish.AllowableValues":["None","Pxe","Floppy","Cd","Hdd","BiosSetup","Utilities","UefiTarget","SDCard","UefiHttp"],"BootSourceOverrideEnabled":"Once","BootSourceOverrideMode":"UEFI"},"Status":{"State":"StandbyOffline","Health":"OK","HealthRollup":"OK"}}'
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Description":"G5
+        Computer System Node","Id":"System-1-1-1-1","IndicatorLED":"Off","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
+        Computer System","PowerState":"PoweringOn","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:40 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:02 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/System.Embedded.1
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2
     body:
       encoding: US-ASCII
       string: ''
@@ -183,48 +158,32 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 76c5d669-2cc3-49f9-9511-9419f16ecc1f
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
   response:
     status:
       code: 200
       message: 'OK '
     headers:
-      Server:
-      - Apache/2.4
-      Cache-Control:
-      - no-cache
-      X-Frame-Options:
-      - DENY
       Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Allow:
-      - POST,PATCH
-      Access-Control-Allow-Origin:
-      - "*"
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Sat, 20 May 2017 09:58:22 GMT
-      Odata-Version:
-      - '4.0'
-      Link:
-      - "</redfish/v1/Schemas/Chassis.v1_0_2.json>;rel=describedby"
+      - Mon, 24 Sep 2018 13:48:03 GMT
       Content-Length:
-      - '2802'
+      - '972'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"Links":{"Contains":[],"ComputerSystems":[{"@odata.id":"/redfish/v1/Systems/System.Embedded.1"}],"PoweredBy@odata.count":0,"PoweredBy":[],"CooledBy@odata.count":12,"ManagersInChassis":[{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1"}],"Contains@odata.count":0,"CooledBy":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],"ManagersInChassis@odata.count":1,"ManagedBy":[{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1"}],"ComputerSystems@odata.count":1,"ManagedBy@odata.count":1},"@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","Manufacturer":"Dell Inc.","PowerState":"Off","Thermal":{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Thermal"},"Name":"Computer
-        System Chassis","AssetTag":null,"SerialNumber":"CN701636AB0013","PhysicalSecurity":{"IntrusionSensor":null,"IntrusionSensorReArm":null,"IntrusionSensorNumber":null},"@odata.type":"#Chassis.v1_2_0.Chassis","IndicatorLED":"Off","SKU":null,"Actions":{"#Chassis.Reset":{"target":"/redfish/v1/Chassis/System.Embedded.1/Actions/Chassis.Reset","ResetType@Redfish.AllowableValues":["On","ForceOff"]}},"Model":"DSS9630M","@odata.id":"/redfish/v1/Chassis/System.Embedded.1","Id":"System.Embedded.1","Power":{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Power"},"PartNumber":"033RF3X04","@odata.context":"/redfish/v1/$metadata#Chassis.Chassis","Location":{"Info":null,"InfoFormat":null},"Status":{"State":"Enabled","Health":"OK","HealthRollup":"OK"},"Description":"It
-        represents the properties for physical components for any system.It represent
-        racks, rackmount servers, blades, standalone, modular systems,enclosures,
-        and all other containers.The non-cpu/device centric parts of the schema are
-        all accessed either directly or indirectly through this resource.","ChassisType":"Enclosure"}'
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-2/Actions/ComputerSystem.Reset"}},"Description":"G5
+        Computer System Node","Id":"System-1-1-1-2","IndicatorLED":"On","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
+        Computer System","PowerState":"Off","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Processors"},"SerialNumber":"23840jr9384j","Status":{"Health":"Warning","State":"Enabled"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:40 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:03 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Processors
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1
     body:
       encoding: US-ASCII
       string: ''
@@ -236,44 +195,31 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 76c5d669-2cc3-49f9-9511-9419f16ecc1f
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
   response:
     status:
       code: 200
       message: 'OK '
     headers:
-      Server:
-      - Apache/2.4
-      Date:
-      - Sat, 20 May 2017 09:58:18 GMT
-      Odata-Version:
-      - '4.0'
-      X-Frame-Options:
-      - DENY
       Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Link:
-      - "</redfish/v1/Schemas/ProcessorCollection.json>;rel=describedby"
-      Cache-Control:
-      - no-cache
-      Access-Control-Allow-Origin:
-      - "*"
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:03 GMT
       Content-Length:
-      - '721'
+      - '1109'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors","Members":[{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.1"},{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.2"}],"@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","@odata.type":"#ProcessorCollection.ProcessorCollection","Description":"Collection
-        of Processors for this System","Members@odata.count":2,"Name":"ProcessorsCollection","@Message.ExtendedInfo":{"Resolution":"Switch-On
-        Host System and retry","MessageId":"Base.1.0.ObjectInfo","Message":"Host system
-        is switched-off","Severity":"WARNING"},"@odata.context":"/redfish/v1/$metadata#ProcessorCollection.ProcessorCollection"}'
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulRestart","GracefulShutdown","PushPowerButton","Nmi"],"target":"/redfish/v1/Systems/System-1-2-1-1/Actions/ComputerSystem.Reset"}},"HostName":"hostname.example.com","Id":"System-1-2-1-1","IndicatorLED":"Blinking","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-2-1"}],"Chassis@odata.count":1},"Manufacturer":"Dell
+        Inc.","MemorySummary":{"MemoryMirroring":"System","Status":{"Health":null,"HealthRollup":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"System","PartNumber":"033RF3X04","PowerState":"On","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":null,"HealthRollup":null,"State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors"},"SerialNumber":"945hjf0927mf","SimpleStorage":{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Storage/Controllers"},"Status":{"Health":"Critical","State":"Disabled"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:40 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:03 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.1
+    uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Sled-1-1-1
     body:
       encoding: US-ASCII
       string: ''
@@ -285,45 +231,31 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 76c5d669-2cc3-49f9-9511-9419f16ecc1f
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
   response:
     status:
       code: 200
       message: 'OK '
     headers:
-      Server:
-      - Apache/2.4
-      Date:
-      - Sat, 20 May 2017 09:58:19 GMT
-      Odata-Version:
-      - '4.0'
-      X-Frame-Options:
-      - DENY
       Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Link:
-      - "</redfish/v1/Schemas/Processor.v1_0_2.json>;rel=describedby"
-      Cache-Control:
-      - no-cache
-      Access-Control-Allow-Origin:
-      - "*"
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:03 GMT
       Content-Length:
-      - '948'
+      - '530'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.1","Id":"CPU.Socket.1","ProcessorId":{"VendorId":"GenuineIntel","Step":"2","EffectiveFamily":"6","MicrocodeInfo":null,"EffectiveModel":"85","IdentificationRegisters":"0x00050652"},"Description":"Represents
-        the properties of a Processor attached to this System","Manufacturer":"Intel","TotalCores":20,"Name":"CPU
-        1","ProcessorArchitecture":[{"Member":"x86"}],"Model":"","@odata.context":"/redfish/v1/$metadata#Processor.Processor","Status":{"State":null,"Health":null},"TotalThreads":40,"Socket":"CPU.Socket.1","ProcessorType":"CPU","@odata.type":"#Processor.v1_0_2.Processor","@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","InstructionSet":[{"Member":"x86-64"}],"MaxSpeedMHz":4000,"@Message.ExtendedInfo":{"Resolution":"Switch-On
-        Host System and retry","MessageId":"Base.1.0.ObjectInfo","Message":"Host system
-        is switched-off","Severity":"WARNING"}}'
+      string: '{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1","ChassisType":"Sled","Description":"G5
+        Sled-Level Enclosure","Id":"Sled-1-1-1","IndicatorLED":"Blinking","Links":{"ComputerSystems":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2"}],"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Block-1-1"}},"Manufacturer":"Dell","Model":"DSS9630M","Name":"G5_Sled","PartNumber":"cnwo8hfn4","PowerState":"Off","SerialNumber":"h894hf5n926h","Status":{"Health":"Warning","State":"StandbyOffline"}}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:40 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:03 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.2
+    uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Block-1-1
     body:
       encoding: US-ASCII
       string: ''
@@ -335,45 +267,32 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 76c5d669-2cc3-49f9-9511-9419f16ecc1f
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
   response:
     status:
       code: 200
       message: 'OK '
     headers:
-      Server:
-      - Apache/2.4
-      Date:
-      - Sat, 20 May 2017 09:58:19 GMT
-      Odata-Version:
-      - '4.0'
-      X-Frame-Options:
-      - DENY
       Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Link:
-      - "</redfish/v1/Schemas/Processor.v1_0_2.json>;rel=describedby"
-      Cache-Control:
-      - no-cache
-      Access-Control-Allow-Origin:
-      - "*"
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:03 GMT
       Content-Length:
-      - '948'
+      - '526'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.2","Id":"CPU.Socket.2","ProcessorId":{"VendorId":"GenuineIntel","Step":"2","EffectiveFamily":"6","MicrocodeInfo":null,"EffectiveModel":"85","IdentificationRegisters":"0x00050652"},"Description":"Represents
-        the properties of a Processor attached to this System","Manufacturer":"Intel","TotalCores":20,"Name":"CPU
-        2","ProcessorArchitecture":[{"Member":"x86"}],"Model":"","@odata.context":"/redfish/v1/$metadata#Processor.Processor","Status":{"State":null,"Health":null},"TotalThreads":40,"Socket":"CPU.Socket.2","ProcessorType":"CPU","@odata.type":"#Processor.v1_0_2.Processor","@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","InstructionSet":[{"Member":"x86-64"}],"MaxSpeedMHz":4000,"@Message.ExtendedInfo":{"Resolution":"Switch-On
-        Host System and retry","MessageId":"Base.1.0.ObjectInfo","Message":"Host system
-        is switched-off","Severity":"WARNING"}}'
+      string: '{"@odata.id":"/redfish/v1/Chassis/Block-1-1","ChassisType":"Enclosure","Description":"G5
+        Block Chassis","Id":"Block-1-1","IndicatorLED":"On","Links":{"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Rack-1"},"Contains":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"},{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-2"}]},"Location":{"Placement":{"Rack":"Rack-1"}},"Manufacturer":"Dell","Model":"G5
+        Block","Name":"G5_Block","PartNumber":"9845ujtf0347","PowerState":"On","SerialNumber":"11","Status":{"Health":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:40 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:03 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Storage/Controllers
+    uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Rack-1
     body:
       encoding: US-ASCII
       string: ''
@@ -385,43 +304,31 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 76c5d669-2cc3-49f9-9511-9419f16ecc1f
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
   response:
     status:
       code: 200
       message: 'OK '
     headers:
-      Server:
-      - Apache/2.4
-      Date:
-      - Sat, 20 May 2017 09:58:17 GMT
-      Odata-Version:
-      - '4.0'
-      X-Frame-Options:
-      - DENY
       Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Link:
-      - "</redfish/v1/Schemas/SimpleStorageCollection.json>;rel=describedby"
-      Cache-Control:
-      - no-cache
-      Access-Control-Allow-Origin:
-      - "*"
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:03 GMT
       Content-Length:
-      - '612'
+      - '621'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Storage/Controllers","@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","@odata.type":"#SimpleStorageCollection.SimpleStorageCollection","Description":"Collection
-        of Controllers for this system","Members@odata.count":2,"Name":"Simple Storage
-        Collection","Members":[{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.2-1"},{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.1-1"}],"@odata.context":"/redfish/v1/$metadata#SimpleStorageCollection.SimpleStorageCollection"}'
+      string: '{"@odata.id":"/redfish/v1/Chassis/Rack-1","Actions":{"#Chassis.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown"],"target":"/redfish/v1/Chassis/Rack-1/Actions/Chassis.Reset"}},"ChassisType":"Rack","Id":"Rack-1","Links":{"Contains":[{"@odata.id":"/redfish/v1/Chassis/Block-1-1"},{"@odata.id":"/redfish/v1/Chassis/Block-1-2"}]},"Location":{"PostalAddress":{"City":"Chesapeake","Country":"VA","HouseNumber":"123","Street":"Adams
+        Ave."}},"Manufacturer":"Dell","Model":"DSS9000","Name":"G5_Rack","PowerState":"On","SerialNumber":"1","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:40 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:03 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.2-1
+    uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Sled-1-2-1
     body:
       encoding: US-ASCII
       string: ''
@@ -433,42 +340,31 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 76c5d669-2cc3-49f9-9511-9419f16ecc1f
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
   response:
     status:
       code: 200
       message: 'OK '
     headers:
-      Server:
-      - Apache/2.4
-      Date:
-      - Sat, 20 May 2017 09:58:18 GMT
-      Odata-Version:
-      - '4.0'
-      X-Frame-Options:
-      - DENY
       Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Link:
-      - "</redfish/v1/Schemas/SimpleStorage.v1_0_2.json>;rel=describedby"
-      Cache-Control:
-      - no-cache
-      Access-Control-Allow-Origin:
-      - "*"
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:03 GMT
       Content-Length:
-      - '544'
+      - '465'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.2-1","Id":"AHCI.Embedded.2-1","Devices":[],"@odata.type":"#SimpleStorage.v1_0_2.SimpleStorage","Description":"Simple
-        Storage Controller","Status":{"State":"Enabled","Health":null,"HealthRollup":null},"Devices@odata.count":0,"@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","Name":"Lewisburg SATA Controller [AHCI mode]","UefiDevicePath":"PciRoot(0x0)/Pci(0x17,0x0)","@odata.context":"/redfish/v1/$metadata#SimpleStorage.SimpleStorage"}'
+      string: '{"@odata.id":"/redfish/v1/Chassis/Sled-1-2-1","ChassisType":"Sled","Description":"G5
+        Sled-Level Enclosure","Id":"Sled-1-2-1","IndicatorLED":"Off","Links":{"ComputerSystems":[{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1"},{"@odata.id":"/redfish/v1/Systems/System-1-2-1-2"}],"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Block-1-2"}},"Manufacturer":"Dell","Model":"DSS9630M","Name":"G5_Sled","PowerState":"Off","Status":{"Health":"OK","State":"StandbyOffline"}}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:40 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:03 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.1-1
+    uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Block-1-2
     body:
       encoding: US-ASCII
       string: ''
@@ -480,39 +376,991 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 76c5d669-2cc3-49f9-9511-9419f16ecc1f
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
   response:
     status:
       code: 200
       message: 'OK '
     headers:
-      Server:
-      - Apache/2.4
-      Date:
-      - Sat, 20 May 2017 09:58:18 GMT
-      Odata-Version:
-      - '4.0'
-      X-Frame-Options:
-      - DENY
       Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Link:
-      - "</redfish/v1/Schemas/SimpleStorage.v1_0_2.json>;rel=describedby"
-      Cache-Control:
-      - no-cache
-      Access-Control-Allow-Origin:
-      - "*"
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:03 GMT
       Content-Length:
-      - '545'
+      - '458'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.1-1","Id":"AHCI.Embedded.1-1","Devices":[],"@odata.type":"#SimpleStorage.v1_0_2.SimpleStorage","Description":"Simple
-        Storage Controller","Status":{"State":"Enabled","Health":null,"HealthRollup":null},"Devices@odata.count":0,"@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","Name":"Lewisburg SSATA Controller [AHCI mode]","UefiDevicePath":"PciRoot(0x0)/Pci(0x11,0x5)","@odata.context":"/redfish/v1/$metadata#SimpleStorage.SimpleStorage"}'
+      string: '{"@odata.id":"/redfish/v1/Chassis/Block-1-2","ChassisType":"Enclosure","Description":"G5
+        Block Chassis","Id":"Block-1-2","Links":{"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Rack-1"},"Contains":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-2-1"}]},"Location":{"Placement":{"Rack":"Rack-1"}},"Manufacturer":"Dell","Model":"G5
+        Block","Name":"G5_Block","PartNumber":"93j4fo3hn4f","PowerState":"On","SerialNumber":"12","Status":{"Health":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:40 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:03 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Processors
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:03 GMT
+      Content-Length:
+      - '226'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors/","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors/1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors/2"}],"Members@odata.count":2}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:03 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Processors/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:03 GMT
+      Content-Length:
+      - '626'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/1/Processors/1","Description":"This
+        resource is used to represent a processor for a Redfish implementation.","Id":"1","InstructionSet":"x86-64","Manufacturer":"Intel(R)
+        Corporation","MaxSpeedMHz":3700,"Model":"Intel(R) Xeon(R) Gold 6126 CPU @
+        2.60GHz","Name":"Processor 1","ProcessorArchitecture":"x86","ProcessorId":{"EffectiveFamily":"0x06","EffectiveModel":"0x55","IdentificationRegisters":"0x00050654bfebfbff","MicrocodeInfo":null,"Step":"0x04","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU
+        1","Status":{"Health":"OK","State":"Enabled"},"TotalCores":12,"TotalThreads":24}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:03 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Processors/2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:03 GMT
+      Content-Length:
+      - '626'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/1/Processors/2","Description":"This
+        resource is used to represent a processor for a Redfish implementation.","Id":"2","InstructionSet":"x86-64","Manufacturer":"Intel(R)
+        Corporation","MaxSpeedMHz":3700,"Model":"Intel(R) Xeon(R) Gold 6126 CPU @
+        2.60GHz","Name":"Processor 2","ProcessorArchitecture":"x86","ProcessorId":{"EffectiveFamily":"0x06","EffectiveModel":"0x55","IdentificationRegisters":"0x00050654bfebfbff","MicrocodeInfo":null,"Step":"0x04","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU
+        2","Status":{"Health":"OK","State":"Enabled"},"TotalCores":12,"TotalThreads":24}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:03 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:03 GMT
+      Content-Length:
+      - '294'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/","Description":"A
+        Collection of Storage resource instances.","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8"}],"Members@odata.count":2}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:03 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:03 GMT
+      Content-Length:
+      - '550'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/","Description":"This
+        resource is used to represent a storage for a Redfish implementation.","Drives":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.0"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.2"}],"Drives@odata.count":3,"Id":"RAID_Slot1","Name":"RAID
+        Storage","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:03 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:03 GMT
+      Content-Length:
+      - '477'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/","Description":"This
+        resource is used to represent a storage for a Redfish implementation.","Drives":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1"}],"Drives@odata.count":2,"Id":"M.2_Slot8","Name":"M.2
+        Storage","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:03 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:03 GMT
+      Content-Length:
+      - '597'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.0","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.0","Identifiers":[{"DurableName":"9847693487","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"984576947398476589","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:03 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:03 GMT
+      Content-Length:
+      - '591'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.1","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.1","Identifiers":[{"DurableName":"9345098734","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"938754938039","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:03 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:03 GMT
+      Content-Length:
+      - '599'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.2","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.2","Identifiers":[{"DurableName":"9854376923746987","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"09834579274032","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:03 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:03 GMT
+      Content-Length:
+      - '580'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0","CapacityBytes":128000000000,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Drive.M.2_Bay0","Identifiers":[{"DurableName":"1234567890","DurableNameFormat":"UUID"}],"Manufacturer":"LEN","MediaType":"SSD","Model":"LITEON
+        CV3-8D128","Name":"128GB M.2 SATA SSD","PartNumber":"SSD0L20505","Protocol":"SATA","Revision":"T87RA34
+        ","RotationSpeedRPM":0,"SerialNumber":"83465192783","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:03 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:03 GMT
+      Content-Length:
+      - '584'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1","CapacityBytes":128000000000,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Drive.M.2_Bay1","Identifiers":[{"DurableName":"1234567891","DurableNameFormat":"UUID"}],"Manufacturer":"LEN","MediaType":"SSD","Model":"LITEON
+        CV3-8D128","Name":"128GB M.2 SATA SSD","PartNumber":"SSD0L20505","Protocol":"SATA","Revision":"T87RA34
+        ","RotationSpeedRPM":0,"SerialNumber":"934759369847658","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:03 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Processors
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:03 GMT
+      Content-Length:
+      - '226'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Processors/","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Processors/1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Processors/2"}],"Members@odata.count":2}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:03 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Processors/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:03 GMT
+      Content-Length:
+      - '639'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Processors/1","Description":"This
+        resource is used to represent a processor for a Redfish implementation.","Id":"1","InstructionSet":"x86-64","Manufacturer":"Intel(R)
+        Corporation","MaxSpeedMHz":3700,"Model":"Intel(R) Xeon(R) Gold 6126 CPU @
+        2.60GHz","Name":"Processor 1","ProcessorArchitecture":"x86","ProcessorId":{"EffectiveFamily":"0x06","EffectiveModel":"0x55","IdentificationRegisters":"0x00050654bfebfbff","MicrocodeInfo":null,"Step":"0x04","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU
+        1","Status":{"Health":"OK","State":"Enabled"},"TotalCores":12,"TotalThreads":24}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:03 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Processors/2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:04 GMT
+      Content-Length:
+      - '639'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Processors/2","Description":"This
+        resource is used to represent a processor for a Redfish implementation.","Id":"2","InstructionSet":"x86-64","Manufacturer":"Intel(R)
+        Corporation","MaxSpeedMHz":3700,"Model":"Intel(R) Xeon(R) Gold 6126 CPU @
+        2.60GHz","Name":"Processor 2","ProcessorArchitecture":"x86","ProcessorId":{"EffectiveFamily":"0x06","EffectiveModel":"0x55","IdentificationRegisters":"0x00050654bfebfbff","MicrocodeInfo":null,"Step":"0x04","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU
+        2","Status":{"Health":"OK","State":"Enabled"},"TotalCores":12,"TotalThreads":24}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:04 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:04 GMT
+      Content-Length:
+      - '294'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/","Description":"A
+        Collection of Storage resource instances.","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8"}],"Members@odata.count":2}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:04 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:04 GMT
+      Content-Length:
+      - '550'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/","Description":"This
+        resource is used to represent a storage for a Redfish implementation.","Drives":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.0"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.2"}],"Drives@odata.count":3,"Id":"RAID_Slot1","Name":"RAID
+        Storage","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:04 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:04 GMT
+      Content-Length:
+      - '477'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/","Description":"This
+        resource is used to represent a storage for a Redfish implementation.","Drives":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1"}],"Drives@odata.count":2,"Id":"M.2_Slot8","Name":"M.2
+        Storage","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:04 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:04 GMT
+      Content-Length:
+      - '595'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.0","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.0","Identifiers":[{"DurableName":"098453t0h432","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"9823jf3149jdf1","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:04 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:04 GMT
+      Content-Length:
+      - '595'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.1","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.1","Identifiers":[{"DurableName":"98483j590j249","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"983j90f8j1349","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:04 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:04 GMT
+      Content-Length:
+      - '600'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.2","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.2","Identifiers":[{"DurableName":"90845j09fj0345","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"9084ut9fm2o3987jn","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:04 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:04 GMT
+      Content-Length:
+      - '581'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0","CapacityBytes":128000000000,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Drive.M.2_Bay0","Identifiers":[{"DurableName":"9345760938","DurableNameFormat":"UUID"}],"Manufacturer":"LEN","MediaType":"SSD","Model":"LITEON
+        CV3-8D128","Name":"128GB M.2 SATA SSD","PartNumber":"SSD0L20505","Protocol":"SATA","Revision":"T87RA34
+        ","RotationSpeedRPM":0,"SerialNumber":"9504868r903j","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:04 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:04 GMT
+      Content-Length:
+      - '584'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1","CapacityBytes":128000000000,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Drive.M.2_Bay1","Identifiers":[{"DurableName":"03485098j4t3098","DurableNameFormat":"UUID"}],"Manufacturer":"LEN","MediaType":"SSD","Model":"LITEON
+        CV3-8D128","Name":"128GB M.2 SATA SSD","PartNumber":"SSD0L20505","Protocol":"SATA","Revision":"T87RA34
+        ","RotationSpeedRPM":0,"SerialNumber":"7rh8o32h47","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:04 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1/Processors
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:04 GMT
+      Content-Length:
+      - '259'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors","Description":"Collection
+        of Processors for this System","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors/CPU.Socket.1"}],"Members@odata.count":1,"Name":"ProcessorsCollection"}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:04 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1/Processors/CPU.Socket.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:04 GMT
+      Content-Length:
+      - '562'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors/CPU.Socket.1","Description":"Represents
+        the properties of a Processor attached to this System","Id":"CPU.Socket.1","InstructionSet":[{"Member":"x86-64"}],"Manufacturer":"Intel","MaxSpeedMHz":4000,"Model":"","Name":"CPU
+        1","ProcessorArchitecture":[{"Member":"x86"}],"ProcessorId":{"EffectiveFamily":"6","EffectiveModel":"85","IdentificationRegisters":"0x00050652","MicrocodeInfo":null,"Step":"2","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU.Socket.1","TotalCores":20,"TotalThreads":40}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:04 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1/Storage/Controllers
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:04 GMT
+      Content-Length:
+      - '288'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Storage/Controllers","Description":"Collection
+        of Controllers for this system","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Storage/Controllers/AHCI.Embedded.1-1"}],"Members@odata.count":1,"Name":"Simple
+        Storage Collection"}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:04 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1/Storage/Controllers/AHCI.Embedded.1-1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - b2ef62d6-f45d-4316-912a-dfefddf4e2c9
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:04 GMT
+      Content-Length:
+      - '453'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Storage/Controllers/AHCI.Embedded.1-1","Description":"Simple
+        Storage Controller","Devices":[{"Name":"Simple storage device 1","Status":{"Health":"OK","State":"Enabled"},"CapacityBytes":274877906944},{"Name":"Simple
+        storage device 2","Status":{"Health":"OK","State":"Enabled"},"CapacityBytes":137438953472}],"Devices@odata.count":2,"Id":"AHCI.Embedded.1-1","Name":"Lewisburg
+        SSATA Controller [AHCI mode]"}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:04 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1
@@ -536,21 +1384,20 @@ http_interactions:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:40 GMT
+      - Mon, 24 Sep 2018 13:48:04 GMT
       Content-Length:
-      - '999'
+      - '362'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.context":"/redfish/v1/$metadata#ServiceRoot.ServiceRoot","@odata.id":"/redfish/v1","@odata.type":"#ServiceRoot.v1_1_0.ServiceRoot","AccountService":{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1/AccountService"},"Chassis":{"@odata.id":"/redfish/v1/Chassis"},"Description":"Root
-        Service","EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","JsonSchemas":{"@odata.id":"/redfish/v1/JSONSchemas"},"Links":{"Sessions":{"@odata.id":"/redfish/v1/Sessions"}},"Managers":{"@odata.id":"/redfish/v1/Managers"},"Name":"Root
-        Service","Oem":{"Dell":{"@odata.type":"/redfish/v1/Schemas/Dell.v1_0_0#Dell.ServiceRoot","IsBranded":0,"ManagerMACAddress":"10:98:36:a9:05:b0","ServiceTag":""}},"RedfishVersion":"1.0.2","Registries":{"@odata.id":"/redfish/v1/Registries"},"SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"Tasks":{"@odata.id":"/redfish/v1/TaskService"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}'
+      string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
+        Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:40 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:04 GMT
 - request:
     method: post
-    uri: https://REDFISH_HOST:8889/redfish/v1/Sessions
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
     body:
       encoding: UTF-8
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
@@ -571,20 +1418,20 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - da3307ec-86a2-4807-a23b-1023ea70f96f
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Thu, 13 Sep 2018 12:28:40 GMT
+      - Mon, 24 Sep 2018 13:48:04 GMT
       Content-Length:
-      - '238'
+      - '253'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Sessions/da3307ec-86a2-4807-a23b-1023ea70f96f","Id":"da3307ec-86a2-4807-a23b-1023ea70f96f","Name":"da3307ec-86a2-4807-a23b-1023ea70f96f","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/7b4aed10-b2a5-4081-88a2-f6af4b4febbd","Id":"7b4aed10-b2a5-4081-88a2-f6af4b4febbd","Name":"7b4aed10-b2a5-4081-88a2-f6af4b4febbd","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:40 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:04 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems
@@ -599,42 +1446,31 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - da3307ec-86a2-4807-a23b-1023ea70f96f
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
   response:
     status:
       code: 200
       message: 'OK '
     headers:
-      Server:
-      - Apache/2.4
-      Date:
-      - Sat, 20 May 2017 09:58:16 GMT
-      Odata-Version:
-      - '4.0'
-      X-Frame-Options:
-      - DENY
       Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Link:
-      - "</redfish/v1/Schemas/ComputerSystemCollection.json>;rel=describedby"
-      Cache-Control:
-      - no-cache
-      Access-Control-Allow-Origin:
-      - "*"
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:04 GMT
       Content-Length:
-      - '438'
+      - '260'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems","@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","@odata.type":"#ComputerSystemCollection.ComputerSystemCollection","Description":"Collection
-        of Computer Systems","Members@odata.count":1,"Name":"Computer System Collection","Members":[{"@odata.id":"/redfish/v1/Systems/System.Embedded.1"}],"@odata.context":"/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection"}'
+      string: '{"@odata.id":"/redfish/v1/Systems","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2"},{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1"}],"Members@odata.count":3,"Name":"Computer
+        System Collection"}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:40 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:04 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
     body:
       encoding: US-ASCII
       string: ''
@@ -646,45 +1482,32 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - da3307ec-86a2-4807-a23b-1023ea70f96f
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
   response:
     status:
       code: 200
       message: 'OK '
     headers:
-      Server:
-      - Apache/2.4
-      Cache-Control:
-      - no-cache
-      X-Frame-Options:
-      - DENY
       Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Allow:
-      - POST,PATCH
-      Access-Control-Allow-Origin:
-      - "*"
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Sat, 20 May 2017 09:58:17 GMT
-      Odata-Version:
-      - '4.0'
-      Link:
-      - "</redfish/v1/Schemas/ComputerSystem.v1_1_0.json>;rel=describedby"
+      - Mon, 24 Sep 2018 13:48:04 GMT
       Content-Length:
-      - '3515'
+      - '984'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"SimpleStorage":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Storage/Controllers"},"Links":{"CooledBy@odata.count":12,"PoweredBy@odata.count":0,"Oem":{"Dell":{"BootSources":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/BootSources"},"@odata.type":"#Dell.v1_0_0.BootSources"}},"ManagedBy":[{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1"}],"Chassis":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1"}],"Chassis@odata.count":1,"PoweredBy":[],"CooledBy":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],"ManagedBy@odata.count":1},"Processors":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors"},"@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","Manufacturer":"Dell Inc.","PowerState":"Off","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff","Name":"System","AssetTag":"","HostName":"","SerialNumber":"CN701636AB0013","@odata.type":"#ComputerSystem.v1_1_0.ComputerSystem","TrustedModules":[{"Status":{"State":"Disabled"}}],"IndicatorLED":"Off","SKU":"","MemorySummary":{"TotalSystemMemoryGiB":32.0,"Status":{"State":"Enabled","Health":null,"HealthRollup":null},"MemoryMirroring":"System"},"Model":"DSS9630M","@odata.id":"/redfish/v1/Systems/System.Embedded.1","Id":"System.Embedded.1","Bios":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Bios"},"SecureBoot":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/SecureBoot"},"ProcessorSummary":{"Status":{"State":"Enabled","Health":null,"HealthRollup":null},"Count":2,"Model":""},"SystemType":"Physical","@odata.context":"/redfish/v1/$metadata#ComputerSystem.ComputerSystem","PartNumber":"033RF3X04","BiosVersion":"0.4.8","EthernetInterfaces":{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"},"Description":"Computer
-        System which represents a machine (physical or virtual) and the local resources
-        such as memory, cpu and other devices that can be accessed from that machine.","Actions":{"#ComputerSystem.Reset":{"target":"/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset","ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulRestart","GracefulShutdown","PushPowerButton","Nmi"]}},"Boot":{"UefiTargetBootSourceOverride":"","BootSourceOverrideTarget":"None","BootSourceOverrideTarget@Redfish.AllowableValues":["None","Pxe","Floppy","Cd","Hdd","BiosSetup","Utilities","UefiTarget","SDCard","UefiHttp"],"BootSourceOverrideEnabled":"Once","BootSourceOverrideMode":"UEFI"},"Status":{"State":"StandbyOffline","Health":"OK","HealthRollup":"OK"}}'
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Description":"G5
+        Computer System Node","Id":"System-1-1-1-1","IndicatorLED":"Off","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
+        Computer System","PowerState":"PoweringOn","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:40 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:04 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/System.Embedded.1
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2
     body:
       encoding: US-ASCII
       string: ''
@@ -696,48 +1519,32 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - da3307ec-86a2-4807-a23b-1023ea70f96f
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
   response:
     status:
       code: 200
       message: 'OK '
     headers:
-      Server:
-      - Apache/2.4
-      Cache-Control:
-      - no-cache
-      X-Frame-Options:
-      - DENY
       Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Allow:
-      - POST,PATCH
-      Access-Control-Allow-Origin:
-      - "*"
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
       Date:
-      - Sat, 20 May 2017 09:58:22 GMT
-      Odata-Version:
-      - '4.0'
-      Link:
-      - "</redfish/v1/Schemas/Chassis.v1_0_2.json>;rel=describedby"
+      - Mon, 24 Sep 2018 13:48:05 GMT
       Content-Length:
-      - '2802'
+      - '972'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"Links":{"Contains":[],"ComputerSystems":[{"@odata.id":"/redfish/v1/Systems/System.Embedded.1"}],"PoweredBy@odata.count":0,"PoweredBy":[],"CooledBy@odata.count":12,"ManagersInChassis":[{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1"}],"Contains@odata.count":0,"CooledBy":[{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._1"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._2"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._3"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._4"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._5"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._6"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._7"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._8"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._9"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._10"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._11"},{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Sensors/Fans/0x17||Fan.Embedded._12"}],"ManagersInChassis@odata.count":1,"ManagedBy":[{"@odata.id":"/redfish/v1/Managers/iDRAC.Embedded.1"}],"ComputerSystems@odata.count":1,"ManagedBy@odata.count":1},"@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","Manufacturer":"Dell Inc.","PowerState":"Off","Thermal":{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Thermal"},"Name":"Computer
-        System Chassis","AssetTag":null,"SerialNumber":"CN701636AB0013","PhysicalSecurity":{"IntrusionSensor":null,"IntrusionSensorReArm":null,"IntrusionSensorNumber":null},"@odata.type":"#Chassis.v1_2_0.Chassis","IndicatorLED":"Off","SKU":null,"Actions":{"#Chassis.Reset":{"target":"/redfish/v1/Chassis/System.Embedded.1/Actions/Chassis.Reset","ResetType@Redfish.AllowableValues":["On","ForceOff"]}},"Model":"DSS9630M","@odata.id":"/redfish/v1/Chassis/System.Embedded.1","Id":"System.Embedded.1","Power":{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/Power"},"PartNumber":"033RF3X04","@odata.context":"/redfish/v1/$metadata#Chassis.Chassis","Location":{"Info":null,"InfoFormat":null},"Status":{"State":"Enabled","Health":"OK","HealthRollup":"OK"},"Description":"It
-        represents the properties for physical components for any system.It represent
-        racks, rackmount servers, blades, standalone, modular systems,enclosures,
-        and all other containers.The non-cpu/device centric parts of the schema are
-        all accessed either directly or indirectly through this resource.","ChassisType":"Enclosure"}'
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-2/Actions/ComputerSystem.Reset"}},"Description":"G5
+        Computer System Node","Id":"System-1-1-1-2","IndicatorLED":"On","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
+        Computer System","PowerState":"Off","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Processors"},"SerialNumber":"23840jr9384j","Status":{"Health":"Warning","State":"Enabled"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:40 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:05 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Processors
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1
     body:
       encoding: US-ASCII
       string: ''
@@ -749,44 +1556,31 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - da3307ec-86a2-4807-a23b-1023ea70f96f
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
   response:
     status:
       code: 200
       message: 'OK '
     headers:
-      Server:
-      - Apache/2.4
-      Date:
-      - Sat, 20 May 2017 09:58:18 GMT
-      Odata-Version:
-      - '4.0'
-      X-Frame-Options:
-      - DENY
       Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Link:
-      - "</redfish/v1/Schemas/ProcessorCollection.json>;rel=describedby"
-      Cache-Control:
-      - no-cache
-      Access-Control-Allow-Origin:
-      - "*"
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:05 GMT
       Content-Length:
-      - '721'
+      - '1109'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors","Members":[{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.1"},{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.2"}],"@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","@odata.type":"#ProcessorCollection.ProcessorCollection","Description":"Collection
-        of Processors for this System","Members@odata.count":2,"Name":"ProcessorsCollection","@Message.ExtendedInfo":{"Resolution":"Switch-On
-        Host System and retry","MessageId":"Base.1.0.ObjectInfo","Message":"Host system
-        is switched-off","Severity":"WARNING"},"@odata.context":"/redfish/v1/$metadata#ProcessorCollection.ProcessorCollection"}'
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulRestart","GracefulShutdown","PushPowerButton","Nmi"],"target":"/redfish/v1/Systems/System-1-2-1-1/Actions/ComputerSystem.Reset"}},"HostName":"hostname.example.com","Id":"System-1-2-1-1","IndicatorLED":"Blinking","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-2-1"}],"Chassis@odata.count":1},"Manufacturer":"Dell
+        Inc.","MemorySummary":{"MemoryMirroring":"System","Status":{"Health":null,"HealthRollup":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"System","PartNumber":"033RF3X04","PowerState":"On","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":null,"HealthRollup":null,"State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors"},"SerialNumber":"945hjf0927mf","SimpleStorage":{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Storage/Controllers"},"Status":{"Health":"Critical","State":"Disabled"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:40 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:05 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.1
+    uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Sled-1-1-1
     body:
       encoding: US-ASCII
       string: ''
@@ -798,45 +1592,31 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - da3307ec-86a2-4807-a23b-1023ea70f96f
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
   response:
     status:
       code: 200
       message: 'OK '
     headers:
-      Server:
-      - Apache/2.4
-      Date:
-      - Sat, 20 May 2017 09:58:19 GMT
-      Odata-Version:
-      - '4.0'
-      X-Frame-Options:
-      - DENY
       Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Link:
-      - "</redfish/v1/Schemas/Processor.v1_0_2.json>;rel=describedby"
-      Cache-Control:
-      - no-cache
-      Access-Control-Allow-Origin:
-      - "*"
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:05 GMT
       Content-Length:
-      - '948'
+      - '530'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.1","Id":"CPU.Socket.1","ProcessorId":{"VendorId":"GenuineIntel","Step":"2","EffectiveFamily":"6","MicrocodeInfo":null,"EffectiveModel":"85","IdentificationRegisters":"0x00050652"},"Description":"Represents
-        the properties of a Processor attached to this System","Manufacturer":"Intel","TotalCores":20,"Name":"CPU
-        1","ProcessorArchitecture":[{"Member":"x86"}],"Model":"","@odata.context":"/redfish/v1/$metadata#Processor.Processor","Status":{"State":null,"Health":null},"TotalThreads":40,"Socket":"CPU.Socket.1","ProcessorType":"CPU","@odata.type":"#Processor.v1_0_2.Processor","@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","InstructionSet":[{"Member":"x86-64"}],"MaxSpeedMHz":4000,"@Message.ExtendedInfo":{"Resolution":"Switch-On
-        Host System and retry","MessageId":"Base.1.0.ObjectInfo","Message":"Host system
-        is switched-off","Severity":"WARNING"}}'
+      string: '{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1","ChassisType":"Sled","Description":"G5
+        Sled-Level Enclosure","Id":"Sled-1-1-1","IndicatorLED":"Blinking","Links":{"ComputerSystems":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2"}],"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Block-1-1"}},"Manufacturer":"Dell","Model":"DSS9630M","Name":"G5_Sled","PartNumber":"cnwo8hfn4","PowerState":"Off","SerialNumber":"h894hf5n926h","Status":{"Health":"Warning","State":"StandbyOffline"}}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:40 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:05 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.2
+    uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Block-1-1
     body:
       encoding: US-ASCII
       string: ''
@@ -848,45 +1628,32 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - da3307ec-86a2-4807-a23b-1023ea70f96f
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
   response:
     status:
       code: 200
       message: 'OK '
     headers:
-      Server:
-      - Apache/2.4
-      Date:
-      - Sat, 20 May 2017 09:58:19 GMT
-      Odata-Version:
-      - '4.0'
-      X-Frame-Options:
-      - DENY
       Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Link:
-      - "</redfish/v1/Schemas/Processor.v1_0_2.json>;rel=describedby"
-      Cache-Control:
-      - no-cache
-      Access-Control-Allow-Origin:
-      - "*"
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:05 GMT
       Content-Length:
-      - '948'
+      - '526'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Processors/CPU.Socket.2","Id":"CPU.Socket.2","ProcessorId":{"VendorId":"GenuineIntel","Step":"2","EffectiveFamily":"6","MicrocodeInfo":null,"EffectiveModel":"85","IdentificationRegisters":"0x00050652"},"Description":"Represents
-        the properties of a Processor attached to this System","Manufacturer":"Intel","TotalCores":20,"Name":"CPU
-        2","ProcessorArchitecture":[{"Member":"x86"}],"Model":"","@odata.context":"/redfish/v1/$metadata#Processor.Processor","Status":{"State":null,"Health":null},"TotalThreads":40,"Socket":"CPU.Socket.2","ProcessorType":"CPU","@odata.type":"#Processor.v1_0_2.Processor","@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","InstructionSet":[{"Member":"x86-64"}],"MaxSpeedMHz":4000,"@Message.ExtendedInfo":{"Resolution":"Switch-On
-        Host System and retry","MessageId":"Base.1.0.ObjectInfo","Message":"Host system
-        is switched-off","Severity":"WARNING"}}'
+      string: '{"@odata.id":"/redfish/v1/Chassis/Block-1-1","ChassisType":"Enclosure","Description":"G5
+        Block Chassis","Id":"Block-1-1","IndicatorLED":"On","Links":{"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Rack-1"},"Contains":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"},{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-2"}]},"Location":{"Placement":{"Rack":"Rack-1"}},"Manufacturer":"Dell","Model":"G5
+        Block","Name":"G5_Block","PartNumber":"9845ujtf0347","PowerState":"On","SerialNumber":"11","Status":{"Health":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:40 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:05 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Storage/Controllers
+    uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Rack-1
     body:
       encoding: US-ASCII
       string: ''
@@ -898,43 +1665,31 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - da3307ec-86a2-4807-a23b-1023ea70f96f
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
   response:
     status:
       code: 200
       message: 'OK '
     headers:
-      Server:
-      - Apache/2.4
-      Date:
-      - Sat, 20 May 2017 09:58:17 GMT
-      Odata-Version:
-      - '4.0'
-      X-Frame-Options:
-      - DENY
       Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Link:
-      - "</redfish/v1/Schemas/SimpleStorageCollection.json>;rel=describedby"
-      Cache-Control:
-      - no-cache
-      Access-Control-Allow-Origin:
-      - "*"
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:05 GMT
       Content-Length:
-      - '612'
+      - '621'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Storage/Controllers","@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","@odata.type":"#SimpleStorageCollection.SimpleStorageCollection","Description":"Collection
-        of Controllers for this system","Members@odata.count":2,"Name":"Simple Storage
-        Collection","Members":[{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.2-1"},{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.1-1"}],"@odata.context":"/redfish/v1/$metadata#SimpleStorageCollection.SimpleStorageCollection"}'
+      string: '{"@odata.id":"/redfish/v1/Chassis/Rack-1","Actions":{"#Chassis.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown"],"target":"/redfish/v1/Chassis/Rack-1/Actions/Chassis.Reset"}},"ChassisType":"Rack","Id":"Rack-1","Links":{"Contains":[{"@odata.id":"/redfish/v1/Chassis/Block-1-1"},{"@odata.id":"/redfish/v1/Chassis/Block-1-2"}]},"Location":{"PostalAddress":{"City":"Chesapeake","Country":"VA","HouseNumber":"123","Street":"Adams
+        Ave."}},"Manufacturer":"Dell","Model":"DSS9000","Name":"G5_Rack","PowerState":"On","SerialNumber":"1","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:40 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:05 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.2-1
+    uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Sled-1-2-1
     body:
       encoding: US-ASCII
       string: ''
@@ -946,42 +1701,31 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - da3307ec-86a2-4807-a23b-1023ea70f96f
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
   response:
     status:
       code: 200
       message: 'OK '
     headers:
-      Server:
-      - Apache/2.4
-      Date:
-      - Sat, 20 May 2017 09:58:18 GMT
-      Odata-Version:
-      - '4.0'
-      X-Frame-Options:
-      - DENY
       Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Link:
-      - "</redfish/v1/Schemas/SimpleStorage.v1_0_2.json>;rel=describedby"
-      Cache-Control:
-      - no-cache
-      Access-Control-Allow-Origin:
-      - "*"
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:05 GMT
       Content-Length:
-      - '544'
+      - '465'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.2-1","Id":"AHCI.Embedded.2-1","Devices":[],"@odata.type":"#SimpleStorage.v1_0_2.SimpleStorage","Description":"Simple
-        Storage Controller","Status":{"State":"Enabled","Health":null,"HealthRollup":null},"Devices@odata.count":0,"@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","Name":"Lewisburg SATA Controller [AHCI mode]","UefiDevicePath":"PciRoot(0x0)/Pci(0x17,0x0)","@odata.context":"/redfish/v1/$metadata#SimpleStorage.SimpleStorage"}'
+      string: '{"@odata.id":"/redfish/v1/Chassis/Sled-1-2-1","ChassisType":"Sled","Description":"G5
+        Sled-Level Enclosure","Id":"Sled-1-2-1","IndicatorLED":"Off","Links":{"ComputerSystems":[{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1"},{"@odata.id":"/redfish/v1/Systems/System-1-2-1-2"}],"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Block-1-2"}},"Manufacturer":"Dell","Model":"DSS9630M","Name":"G5_Sled","PowerState":"Off","Status":{"Health":"OK","State":"StandbyOffline"}}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:40 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:05 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.1-1
+    uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Block-1-2
     body:
       encoding: US-ASCII
       string: ''
@@ -993,37 +1737,989 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - da3307ec-86a2-4807-a23b-1023ea70f96f
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
   response:
     status:
       code: 200
       message: 'OK '
     headers:
-      Server:
-      - Apache/2.4
-      Date:
-      - Sat, 20 May 2017 09:58:18 GMT
-      Odata-Version:
-      - '4.0'
-      X-Frame-Options:
-      - DENY
       Content-Type:
-      - application/json;odata.metadata=minimal;charset=utf-8
-      Link:
-      - "</redfish/v1/Schemas/SimpleStorage.v1_0_2.json>;rel=describedby"
-      Cache-Control:
-      - no-cache
-      Access-Control-Allow-Origin:
-      - "*"
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:05 GMT
       Content-Length:
-      - '545'
+      - '458'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System.Embedded.1/Storage/Controllers/AHCI.Embedded.1-1","Id":"AHCI.Embedded.1-1","Devices":[],"@odata.type":"#SimpleStorage.v1_0_2.SimpleStorage","Description":"Simple
-        Storage Controller","Status":{"State":"Enabled","Health":null,"HealthRollup":null},"Devices@odata.count":0,"@redfish.copyright":"Copyright  2017  Dell,
-        Inc.  All rights reserved","Name":"Lewisburg SSATA Controller [AHCI mode]","UefiDevicePath":"PciRoot(0x0)/Pci(0x11,0x5)","@odata.context":"/redfish/v1/$metadata#SimpleStorage.SimpleStorage"}'
+      string: '{"@odata.id":"/redfish/v1/Chassis/Block-1-2","ChassisType":"Enclosure","Description":"G5
+        Block Chassis","Id":"Block-1-2","Links":{"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Rack-1"},"Contains":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-2-1"}]},"Location":{"Placement":{"Rack":"Rack-1"}},"Manufacturer":"Dell","Model":"G5
+        Block","Name":"G5_Block","PartNumber":"93j4fo3hn4f","PowerState":"On","SerialNumber":"12","Status":{"Health":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 12:28:40 GMT
+  recorded_at: Mon, 24 Sep 2018 13:48:05 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Processors
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:05 GMT
+      Content-Length:
+      - '226'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors/","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors/1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors/2"}],"Members@odata.count":2}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:05 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Processors/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:05 GMT
+      Content-Length:
+      - '626'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/1/Processors/1","Description":"This
+        resource is used to represent a processor for a Redfish implementation.","Id":"1","InstructionSet":"x86-64","Manufacturer":"Intel(R)
+        Corporation","MaxSpeedMHz":3700,"Model":"Intel(R) Xeon(R) Gold 6126 CPU @
+        2.60GHz","Name":"Processor 1","ProcessorArchitecture":"x86","ProcessorId":{"EffectiveFamily":"0x06","EffectiveModel":"0x55","IdentificationRegisters":"0x00050654bfebfbff","MicrocodeInfo":null,"Step":"0x04","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU
+        1","Status":{"Health":"OK","State":"Enabled"},"TotalCores":12,"TotalThreads":24}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:05 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Processors/2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:05 GMT
+      Content-Length:
+      - '626'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/1/Processors/2","Description":"This
+        resource is used to represent a processor for a Redfish implementation.","Id":"2","InstructionSet":"x86-64","Manufacturer":"Intel(R)
+        Corporation","MaxSpeedMHz":3700,"Model":"Intel(R) Xeon(R) Gold 6126 CPU @
+        2.60GHz","Name":"Processor 2","ProcessorArchitecture":"x86","ProcessorId":{"EffectiveFamily":"0x06","EffectiveModel":"0x55","IdentificationRegisters":"0x00050654bfebfbff","MicrocodeInfo":null,"Step":"0x04","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU
+        2","Status":{"Health":"OK","State":"Enabled"},"TotalCores":12,"TotalThreads":24}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:05 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:05 GMT
+      Content-Length:
+      - '294'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/","Description":"A
+        Collection of Storage resource instances.","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8"}],"Members@odata.count":2}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:05 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:05 GMT
+      Content-Length:
+      - '550'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/","Description":"This
+        resource is used to represent a storage for a Redfish implementation.","Drives":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.0"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.2"}],"Drives@odata.count":3,"Id":"RAID_Slot1","Name":"RAID
+        Storage","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:05 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:05 GMT
+      Content-Length:
+      - '477'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/","Description":"This
+        resource is used to represent a storage for a Redfish implementation.","Drives":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1"}],"Drives@odata.count":2,"Id":"M.2_Slot8","Name":"M.2
+        Storage","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:05 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:05 GMT
+      Content-Length:
+      - '597'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.0","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.0","Identifiers":[{"DurableName":"9847693487","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"984576947398476589","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:05 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:05 GMT
+      Content-Length:
+      - '591'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.1","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.1","Identifiers":[{"DurableName":"9345098734","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"938754938039","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:05 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:05 GMT
+      Content-Length:
+      - '599'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.2","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.2","Identifiers":[{"DurableName":"9854376923746987","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"09834579274032","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:05 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:05 GMT
+      Content-Length:
+      - '580'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0","CapacityBytes":128000000000,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Drive.M.2_Bay0","Identifiers":[{"DurableName":"1234567890","DurableNameFormat":"UUID"}],"Manufacturer":"LEN","MediaType":"SSD","Model":"LITEON
+        CV3-8D128","Name":"128GB M.2 SATA SSD","PartNumber":"SSD0L20505","Protocol":"SATA","Revision":"T87RA34
+        ","RotationSpeedRPM":0,"SerialNumber":"83465192783","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:05 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:05 GMT
+      Content-Length:
+      - '584'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1","CapacityBytes":128000000000,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Drive.M.2_Bay1","Identifiers":[{"DurableName":"1234567891","DurableNameFormat":"UUID"}],"Manufacturer":"LEN","MediaType":"SSD","Model":"LITEON
+        CV3-8D128","Name":"128GB M.2 SATA SSD","PartNumber":"SSD0L20505","Protocol":"SATA","Revision":"T87RA34
+        ","RotationSpeedRPM":0,"SerialNumber":"934759369847658","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:05 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Processors
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:05 GMT
+      Content-Length:
+      - '226'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Processors/","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Processors/1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Processors/2"}],"Members@odata.count":2}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:05 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Processors/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:05 GMT
+      Content-Length:
+      - '639'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Processors/1","Description":"This
+        resource is used to represent a processor for a Redfish implementation.","Id":"1","InstructionSet":"x86-64","Manufacturer":"Intel(R)
+        Corporation","MaxSpeedMHz":3700,"Model":"Intel(R) Xeon(R) Gold 6126 CPU @
+        2.60GHz","Name":"Processor 1","ProcessorArchitecture":"x86","ProcessorId":{"EffectiveFamily":"0x06","EffectiveModel":"0x55","IdentificationRegisters":"0x00050654bfebfbff","MicrocodeInfo":null,"Step":"0x04","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU
+        1","Status":{"Health":"OK","State":"Enabled"},"TotalCores":12,"TotalThreads":24}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Processors/2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:06 GMT
+      Content-Length:
+      - '639'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Processors/2","Description":"This
+        resource is used to represent a processor for a Redfish implementation.","Id":"2","InstructionSet":"x86-64","Manufacturer":"Intel(R)
+        Corporation","MaxSpeedMHz":3700,"Model":"Intel(R) Xeon(R) Gold 6126 CPU @
+        2.60GHz","Name":"Processor 2","ProcessorArchitecture":"x86","ProcessorId":{"EffectiveFamily":"0x06","EffectiveModel":"0x55","IdentificationRegisters":"0x00050654bfebfbff","MicrocodeInfo":null,"Step":"0x04","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU
+        2","Status":{"Health":"OK","State":"Enabled"},"TotalCores":12,"TotalThreads":24}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:06 GMT
+      Content-Length:
+      - '294'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/","Description":"A
+        Collection of Storage resource instances.","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8"}],"Members@odata.count":2}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:06 GMT
+      Content-Length:
+      - '550'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/","Description":"This
+        resource is used to represent a storage for a Redfish implementation.","Drives":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.0"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.2"}],"Drives@odata.count":3,"Id":"RAID_Slot1","Name":"RAID
+        Storage","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:06 GMT
+      Content-Length:
+      - '477'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/","Description":"This
+        resource is used to represent a storage for a Redfish implementation.","Drives":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1"}],"Drives@odata.count":2,"Id":"M.2_Slot8","Name":"M.2
+        Storage","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:06 GMT
+      Content-Length:
+      - '595'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.0","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.0","Identifiers":[{"DurableName":"098453t0h432","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"9823jf3149jdf1","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:06 GMT
+      Content-Length:
+      - '595'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.1","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.1","Identifiers":[{"DurableName":"98483j590j249","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"983j90f8j1349","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:06 GMT
+      Content-Length:
+      - '600'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.2","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.2","Identifiers":[{"DurableName":"90845j09fj0345","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"9084ut9fm2o3987jn","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:06 GMT
+      Content-Length:
+      - '581'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0","CapacityBytes":128000000000,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Drive.M.2_Bay0","Identifiers":[{"DurableName":"9345760938","DurableNameFormat":"UUID"}],"Manufacturer":"LEN","MediaType":"SSD","Model":"LITEON
+        CV3-8D128","Name":"128GB M.2 SATA SSD","PartNumber":"SSD0L20505","Protocol":"SATA","Revision":"T87RA34
+        ","RotationSpeedRPM":0,"SerialNumber":"9504868r903j","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:06 GMT
+      Content-Length:
+      - '584'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1","CapacityBytes":128000000000,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Drive.M.2_Bay1","Identifiers":[{"DurableName":"03485098j4t3098","DurableNameFormat":"UUID"}],"Manufacturer":"LEN","MediaType":"SSD","Model":"LITEON
+        CV3-8D128","Name":"128GB M.2 SATA SSD","PartNumber":"SSD0L20505","Protocol":"SATA","Revision":"T87RA34
+        ","RotationSpeedRPM":0,"SerialNumber":"7rh8o32h47","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1/Processors
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:06 GMT
+      Content-Length:
+      - '259'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors","Description":"Collection
+        of Processors for this System","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors/CPU.Socket.1"}],"Members@odata.count":1,"Name":"ProcessorsCollection"}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1/Processors/CPU.Socket.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:06 GMT
+      Content-Length:
+      - '562'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors/CPU.Socket.1","Description":"Represents
+        the properties of a Processor attached to this System","Id":"CPU.Socket.1","InstructionSet":[{"Member":"x86-64"}],"Manufacturer":"Intel","MaxSpeedMHz":4000,"Model":"","Name":"CPU
+        1","ProcessorArchitecture":[{"Member":"x86"}],"ProcessorId":{"EffectiveFamily":"6","EffectiveModel":"85","IdentificationRegisters":"0x00050652","MicrocodeInfo":null,"Step":"2","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU.Socket.1","TotalCores":20,"TotalThreads":40}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1/Storage/Controllers
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:06 GMT
+      Content-Length:
+      - '288'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Storage/Controllers","Description":"Collection
+        of Controllers for this system","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Storage/Controllers/AHCI.Embedded.1-1"}],"Members@odata.count":1,"Name":"Simple
+        Storage Collection"}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1/Storage/Controllers/AHCI.Embedded.1-1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 7b4aed10-b2a5-4081-88a2-f6af4b4febbd
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      Date:
+      - Mon, 24 Sep 2018 13:48:06 GMT
+      Content-Length:
+      - '453'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Storage/Controllers/AHCI.Embedded.1-1","Description":"Simple
+        Storage Controller","Devices":[{"Name":"Simple storage device 1","Status":{"Health":"OK","State":"Enabled"},"CapacityBytes":274877906944},{"Name":"Simple
+        storage device 2","Status":{"Health":"OK","State":"Enabled"},"CapacityBytes":137438953472}],"Devices@odata.count":2,"Id":"AHCI.Embedded.1-1","Name":"Lewisburg
+        SSATA Controller [AHCI mode]"}'
+    http_version: 
+  recorded_at: Mon, 24 Sep 2018 13:48:06 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Old test data was missing quite a few pieces of information, which made it hard to test the inventory refresh process thoroughly.

New set of data contains data of better quality:

  * has more than one server,
  * servers actually contain some disks,
  * servers are placed in racks/chassis,
  * chassis are nested,
  * components contains location data.

~~Depends on #31~~
