### PR TITLE
Add event catcher for Redfish provider

### DIFF
--- a/app/models/manageiq/providers/redfish/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager.rb
@@ -1,5 +1,7 @@
 module ManageIQ::Providers::Redfish
   class PhysicalInfraManager < ManageIQ::Providers::PhysicalInfraManager
+    require_nested :EventCatcher
+    require_nested :EventParser
     require_nested :Refresher
     require_nested :RefreshWorker
 

--- a/app/models/manageiq/providers/redfish/physical_infra_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager/event_catcher.rb
@@ -1,0 +1,6 @@
+module ManageIQ::Providers::Redfish
+  class PhysicalInfraManager::EventCatcher \
+      < ManageIQ::Providers::BaseManager::EventCatcher
+    require_nested :Runner
+  end
+end

--- a/app/models/manageiq/providers/redfish/physical_infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager/event_catcher/runner.rb
@@ -1,0 +1,25 @@
+module ManageIQ::Providers::Redfish
+  class PhysicalInfraManager::EventCatcher::Runner \
+      < ManageIQ::Providers::BaseManager::EventCatcher::Runner
+    def monitor_events
+      event_stream.listen do |event|
+        event_monitor_running
+        @queue << event
+      end
+    end
+
+    def stop_event_monitor
+    end
+
+    def queue_event(event)
+      h = PhysicalInfraManager::EventParser.event_to_hash(event, @cfg[:ems_id])
+      EmsEvent.add_queue("add", @cfg[:ems_id], h)
+    end
+
+    private
+
+    def event_stream
+      @event_stream ||= @ems.with_provider_connection(&:event_listener)
+    end
+  end
+end

--- a/app/models/manageiq/providers/redfish/physical_infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager/event_parser.rb
@@ -1,0 +1,15 @@
+module ManageIQ::Providers::Redfish
+  class PhysicalInfraManager::EventParser
+    def self.event_to_hash(event, ems_id)
+      {
+        :ems_id     => ems_id,
+        :ems_ref    => event["EventId"],
+        :event_type => "redfish_#{event["MessageId"]}",
+        :full_data  => event,
+        :message    => event["Message"],
+        :source     => "REDFISH",
+        :timestamp  => event["EventTimestamp"] || Time.now.utc.to_s,
+      }
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,6 +4,9 @@
     :blacklisted_event_names: []
     :event_handling:
       :event_groups:
+        :general:
+          :critical:
+          - !ruby/regexp /^redfish_/
 
 :ems_refresh:
   :redfish_ph_infra:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,3 +24,5 @@
     :queue_worker_base:
       :ems_refresh_worker:
         :ems_refresh_worker_redfish_physical_infra: {}
+    :event_catcher:
+      :event_catcher_redfish: {}

--- a/manageiq-providers-redfish.gemspec
+++ b/manageiq-providers-redfish.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency "redfish_client", "~> 0.1"
+  s.add_runtime_dependency "redfish_client", "~> 0.4"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "redfish_tools", "~> 0.1"

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/event_catcher_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/event_catcher_spec.rb
@@ -1,0 +1,10 @@
+describe ManageIQ::Providers::Redfish::PhysicalInfraManager::EventCatcher do
+  it '.ems_class' do
+    expect(described_class.ems_class)
+      .to eq(ManageIQ::Providers::Redfish::PhysicalInfraManager)
+  end
+
+  it ".settings_name" do
+    expect(described_class.settings_name).to eq(:event_catcher_redfish)
+  end
+end

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/event_parser_spec.rb
@@ -1,0 +1,31 @@
+describe ManageIQ::Providers::Redfish::PhysicalInfraManager::EventParser do
+  let(:event) do
+    {
+      "Context"           => "context",
+      "EventId"           => "8579",
+      "EventTimestamp"    => "2018-09-19T12:25:27-0500",
+      "EventType"         => "Alert",
+      "MemberId"          => "32a734e0-bc29-11e8-8179-509a4c6c87ab",
+      "Message"           => "System is turning off.",
+      "MessageId"         => "SYS1001",
+      "OriginOfCondition" => {
+        "@odata.id" => "/redfish/v1/Systems/System-1-1-1-1"
+      },
+      "Severity"          => "Informational",
+    }
+  end
+
+  context ".event_to_hash" do
+    it "parses event data" do
+      expect(described_class.event_to_hash(event, 1234)).to eq(
+        :ems_id     => 1234,
+        :ems_ref    => "8579",
+        :event_type => "redfish_SYS1001",
+        :full_data  => event,
+        :message    => "System is turning off.",
+        :source     => "REDFISH",
+        :timestamp  => "2018-09-19T12:25:27-0500",
+      )
+    end
+  end
+end


### PR DESCRIPTION
This event catcher streams events from Redfis service in the for of server-sent events as described in the Redfish API standard.

@miq-bot assign @agrare 
/cc @matejart 