### PR TITLE
Restrict Redfsh client gem version more tightly

### DIFF
--- a/manageiq-providers-redfish.gemspec
+++ b/manageiq-providers-redfish.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency "redfish_client", "~> 0.4"
+  s.add_runtime_dependency "redfish_client", "~> 0.4.0"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "redfish_tools", "~> 0.1"


### PR DESCRIPTION
In order to prevent redfish provider from breaking on client updates, we restrict it to version 0.4.x.

In the perfect world, we would use latest stable release, but unfortunately, Redfish client is relatively new gem and has no stable release yet.

@miq-bot assign @agrare 
@miq-bot add_label hammer:yes