### PR TITLE
Fix deprecation on static attributes

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -10,8 +10,8 @@ FactoryBot.define do
     end
 
     trait :vcr do
-      security_protocol "ssl"
-      port 8889
+      security_protocol { "ssl" }
+      port { 8889 }
 
       hostname do
         # Keep in sync with filter_sensitive_data in spec/spec_helper.rb!

--- a/spec/factories/physical_server.rb
+++ b/spec/factories/physical_server.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
           :class  => "ManageIQ::Providers::Redfish::PhysicalInfraManager::PhysicalServer",
           :parent => :physical_server do
     trait :vcr do
-      ems_ref "/redfish/v1/Systems/System.Embedded.1"
+      ems_ref { "/redfish/v1/Systems/System.Embedded.1" }
     end
   end
 end


### PR DESCRIPTION
Fixes:
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:

ems_ref { "/redfish/v1/Systems/System.Embedded.1" }

To automatically update from static attributes to dynamic ones,
install rubocop-rspec and run:

rubocop \
  --require rubocop-rspec \
  --only FactoryBot/AttributeDefinedStatically \
  --auto-correct