### PR TITLE
Physical server provisioning via StateMachine

### DIFF
--- a/app/models/manageiq/providers/redfish/physical_infra_manager/physical_server.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager/physical_server.rb
@@ -1,5 +1,7 @@
 module ManageIQ::Providers::Redfish
   class PhysicalInfraManager::PhysicalServer < ::PhysicalServer
+    include_concern 'Provisioning'
+
     def self.display_name(number = 1)
       n_('Physical Server (Redfish)', 'Physical Servers (Redfish)', number)
     end

--- a/app/models/manageiq/providers/redfish/physical_infra_manager/physical_server/provisioning.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager/physical_server/provisioning.rb
@@ -1,0 +1,42 @@
+module ManageIQ::Providers::Redfish
+  module PhysicalInfraManager::PhysicalServer::Provisioning
+    def deploy_pxe_config(pxe_image, customization_template)
+      with_provider_object do |system|
+        if (macs = mac_addresses(system)).empty?
+          raise MiqException::MiqProvisionError, 'at least one MAC address is needed for provisioning'
+        end
+        macs.each { |mac| pxe_image.pxe_server.create_provisioning_files(pxe_image, mac, nil, customization_template) }
+      end
+    end
+
+    def reboot_using_pxe
+      with_provider_object do |system|
+        response = system.patch(
+          :payload => {
+            'Boot' => {
+              'BootSourceOverrideEnabled' => 'Once',
+              'BootSourceOverrideTarget'  => 'Pxe'
+            }
+          }
+        )
+        raise MiqException::MiqProvisionError, 'Cannot override boot order' if response.status >= 400
+      end
+      # TODO: we perform force reboot which will fail in some cases. Need to handle with supports mixin.
+      restart_now
+    end
+
+    def powered_on_now?
+      # TODO(miha-plesko): we should rely on VMDB state instead contacting provider.
+      # Update implementation once we have event-driven targeted refresh implemented.
+      with_provider_object { |system| return system.PowerState.to_s.downcase == 'on' }
+    end
+
+    private
+
+    def mac_addresses(system)
+      system.EthernetInterfaces.Members.reduce(Set.new) do |acc, el|
+        acc.add(el.PermanentMACAddress).add(el.MACAddress)
+      end.keep_if(&:present?)
+    end
+  end
+end

--- a/app/models/manageiq/providers/redfish/physical_infra_manager/provision.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager/provision.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::Redfish::PhysicalInfraManager::Provision < ::PhysicalServerProvisionTask
+  include_concern 'StateMachine'
+end

--- a/app/models/manageiq/providers/redfish/physical_infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager/provision/state_machine.rb
@@ -1,0 +1,32 @@
+module ManageIQ::Providers::Redfish::PhysicalInfraManager::Provision::StateMachine
+  def start_provisioning
+    update_and_notify_parent(:message => msg('start provisioning'))
+    signal :deploy_pxe_config
+  end
+
+  def deploy_pxe_config
+    update_and_notify_parent(:message => msg('deploy pxe config'))
+    unless (pxe_image = PxeImage.find_by(:id => options[:pxe_image_id]))
+      raise MiqException::MiqProvisionError, "PXE Image with id #{options[:pxe_image_id]} not found"
+    end
+    unless (template = CustomizationTemplate.find_by(:id => options[:customization_template_id]))
+      raise MiqException::MiqProvisionError, "CustomizationTemplate with id #{options[:customization_template_id]} not found"
+    end
+    source.deploy_pxe_config(pxe_image, template)
+    signal :reboot_using_pxe
+  end
+
+  def reboot_using_pxe
+    update_and_notify_parent(:message => msg('reboot using PXE'))
+    source.reboot_using_pxe
+    signal :poll_server_running
+  end
+
+  def poll_server_running
+    if source.powered_on_now?
+      signal :done_provisioning
+    else
+      requeue_phase
+    end
+  end
+end

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/physical_server/provisioning_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/physical_server/provisioning_spec.rb
@@ -1,0 +1,71 @@
+describe ManageIQ::Providers::Redfish::PhysicalInfraManager::PhysicalServer do
+  before do
+    allow(subject).to receive(:with_provider_object).and_yield(system)
+  end
+
+  let(:system)     { double('SYSTEM', :EthernetInterfaces => double(:Members => macs)) }
+  let(:macs)       { [] }
+  let(:pxe_image)  { FactoryBot.create(:pxe_image, :pxe_server => pxe_server) }
+  let(:pxe_server) { FactoryBot.create(:pxe_server) }
+  let(:template)   { FactoryBot.create(:customization_template) }
+
+  describe '#deploy_pxe_config' do
+    context 'when without macs' do
+      let(:macs) { [] }
+      it 'is provisioning aborted' do
+        expect { subject.deploy_pxe_config(pxe_image, template) }.to raise_error(MiqException::MiqProvisionError)
+      end
+    end
+
+    context 'when multiple macs' do
+      let(:macs) { [double('MAC 1', :PermanentMACAddress => 'addr1', :MACAddress => 'addr2')] }
+      it 'pxe is configured for each mac' do
+        expect(pxe_server).to receive(:create_provisioning_files).with(pxe_image, 'addr1', nil, template)
+        expect(pxe_server).to receive(:create_provisioning_files).with(pxe_image, 'addr2', nil, template)
+        subject.deploy_pxe_config(pxe_image, template)
+      end
+    end
+
+    context 'when duplicated macs' do
+      let(:macs) do
+        [
+          double('MAC 1', :PermanentMACAddress => 'same-addr', :MACAddress => 'same-addr'),
+          double('MAC 2', :PermanentMACAddress => 'same-addr', :MACAddress => 'same-addr')
+        ]
+      end
+      it 'pxe is configured for each unique mac' do
+        expect(pxe_server).to receive(:create_provisioning_files).with(pxe_image, 'same-addr', nil, template).once
+        subject.deploy_pxe_config(pxe_image, template)
+      end
+    end
+  end
+
+  describe '#reboot_using_pxe' do
+    context 'when boot order setup succeeds' do
+      it 'server is restarted' do
+        expect(system).to receive(:patch).and_return(double('RESPONSE', :status => 200))
+        expect(subject).to receive(:restart_now)
+        subject.reboot_using_pxe
+      end
+    end
+
+    context 'when boot order setup fails' do
+      it 'is provisioning aborted' do
+        expect(system).to receive(:patch).and_return(double('RESPONSE', :status => 400))
+        expect { subject.reboot_using_pxe }.to raise_error(MiqException::MiqProvisionError)
+      end
+    end
+  end
+
+  describe '#powered_on_now?' do
+    context 'when On' do
+      before { allow(system).to receive(:PowerState).and_return('On') }
+      it { expect(subject.powered_on_now?).to be_truthy }
+    end
+
+    context 'when Off' do
+      before { allow(system).to receive(:PowerState).and_return('Off') }
+      it { expect(subject.powered_on_now?).to be_falsey }
+    end
+  end
+end

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/provision/state_machine.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/provision/state_machine.rb
@@ -1,0 +1,59 @@
+describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Provision do
+  before { EvmSpecHelper.create_guid_miq_server_zone }
+
+  let(:server)    { FactoryBot.create(:physical_server) }
+  let(:request)   { FactoryBot.create(:physical_server_provision_request) }
+  let(:pxe_image) { FactoryBot.create(:pxe_image) }
+  let(:template)  { FactoryBot.create(:customization_template) }
+
+  subject { described_class.new(:source => server, :miq_request => request) }
+
+  describe 'run state machine' do
+    before { subject.update_attribute(:options, options) }
+    before { allow(subject).to receive(:requeue_phase) { subject.send(subject.phase) } }
+    before do
+      allow(subject).to receive(:signal) do |method|
+        subject.phase = method
+        subject.send(method)
+      end
+    end
+
+    context 'abort when missing pxe image' do
+      let(:options) { { :pxe_image_id => 'missing' } }
+      it do
+        expect { subject.start_provisioning }.to raise_error(MiqException::MiqProvisionError)
+      end
+    end
+
+    context 'abort when missing customization template' do
+      let(:options) { { :configuration_profile_id => 'missing' } }
+      it do
+        expect { subject.start_provisioning }.to raise_error(MiqException::MiqProvisionError)
+      end
+    end
+
+    context 'when all steps succeed' do
+      let(:options) { { :pxe_image_id => pxe_image.id, :configuration_profile_id => template.id } }
+      it do
+        expect(server).to receive(:deploy_pxe_config).with(pxe_image, template)
+        expect(server).to receive(:reboot_using_pxe)
+        expect(server).to receive(:powered_on_now?).and_return(true)
+
+        expect(subject).to receive(:done_provisioning)
+        subject.start_provisioning
+      end
+    end
+
+    context 'when all steps succeed after polling' do
+      let(:options) { { :pxe_image_id => pxe_image.id, :configuration_profile_id => template.id } }
+      it do
+        expect(server).to receive(:deploy_pxe_config).with(pxe_image, template)
+        expect(server).to receive(:reboot_using_pxe)
+        expect(server).to receive(:powered_on_now?).and_return(false, false, true)
+
+        expect(subject).to receive(:done_provisioning)
+        subject.start_provisioning
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi guys, I'm sending in a series of PRs that all aim to start provisioning physical servers by means of a new StateMachine which is supposed to also take care of different kind of physical servers (talking Lenovo XClarity vs RedFish here). It's still a WIP, but the code alread works. 

- [ ] https://github.com/ManageIQ/manageiq-providers-redfish/pull/58 (React Component)
- [x] https://github.com/ManageIQ/manageiq-providers-redfish/pull/60 (with_provider_object)
- [x] https://github.com/ManageIQ/manageiq-api/pull/578
- [x] https://github.com/ManageIQ/manageiq/pull/18573
- [x] https://github.com/ManageIQ/manageiq-automation_engine/pull/306
- [x] https://github.com/ManageIQ/manageiq-content/pull/516
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/5461

---
On this PR we implement PhysicalServer provisioning (internal) state machine. Provisioning is done in three steps:

```
- deploy_pxe_config
- reboot_using_pxe
- poll_server_running
```

We assume provisioning request is triggered with following options:

```
POST /api/requests
{
  "options" : {
	"request_type" : "provision_physical_server",
	"src_ids": [1, 2, 3],           # list of PhysicalServers to provision
	"pxe_image_id": 1,              # what PXE Image to use
	"customization_template_id": 1  # what customization template to use
  }
}
```

Please note that the internal state machine (implemented in this commit) is executed per src_id. In the example above, the internal state machine would get executed three times: once for PhysicalServer id=1, once for id=2 and once for id=3.

Please also note that each phase of the state machine is lightweight - because a single worker can only grab&execute one phase at a time which means a long-running phase blocks all other state machines.
