### PR TITLE
React Component that triggers Provisioning Request

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,31 @@
+{
+  "presets": [
+    [
+      "env",
+      {
+        "targets": {
+          "browsers": [
+            "> 1%",
+            "last 2 versions",
+            "Firefox ESR",
+            "IE 10",
+            "IE 11"
+          ]
+        }
+      }
+    ],
+    "react",
+    "es2015",
+  ],
+  "plugins": [
+    "transform-class-properties",
+    "transform-export-extensions",
+    "transform-object-rest-spread",
+    "transform-object-assign"
+  ],
+  "env": {
+    "test": {
+      "plugins": ["transform-es2015-modules-commonjs"]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 /config/environments/*.local.yml
 
 /spec/manageiq
+
+node_modules/
+yarn.lock

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# using yarn
+package-lock = false

--- a/.postcssrc.yml
+++ b/.postcssrc.yml
@@ -1,0 +1,4 @@
+plugins:
+  postcss-smart-import: {}
+  precss: {}
+  autoprefixer: {}

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,25 @@ notifications:
     on_success: change
     on_failure: always
     on_start: never
-cache: bundler
+cache:
+  bundler: true
+  yarn: true
 env:
   global:
   - RUBY_GC_HEAP_GROWTH_MAX_SLOTS=300000
   - RUBY_GC_HEAP_INIT_SLOTS=600000
   - RUBY_GC_HEAP_GROWTH_FACTOR=1.25
+  matrix:
+    - TEST_SUITE=spec
+    - TEST_SUITE=yarn:test
+matrix:
+  exclude:
+    - rvm: 2.4.5
+      env: TEST_SUITE=yarn:test
 addons:
   postgresql: '10'
-install: bin/setup
+install:
+- bin/setup
+- "bundle exec rake yarn:install"
+script: bundle exec rake $TEST_SUITE
 after_script: bundle exec codeclimate-test-reporter

--- a/Rakefile
+++ b/Rakefile
@@ -13,4 +13,18 @@ require 'bundler/gem_tasks'
 
 FileList['lib/tasks_private/**/*.rake'].each { |r| load r }
 
+namespace :yarn do
+  desc "install yarn dependencies"
+  task :install do
+    system('yarn install')
+    exit $CHILD_STATUS.exitstatus
+  end
+
+  desc "run jest tests"
+  task :test do
+    system('yarn test')
+    exit $CHILD_STATUS.exitstatus
+  end
+end
+
 task :default => :spec

--- a/app/helpers/manageiq/providers/redfish/toolbar_overrides/physical_server_center.rb
+++ b/app/helpers/manageiq/providers/redfish/toolbar_overrides/physical_server_center.rb
@@ -1,0 +1,35 @@
+module ManageIQ::Providers::Redfish
+  class ToolbarOverrides::PhysicalServerCenter \
+      < ::ApplicationHelper::Toolbar::Override
+    button_group(
+      "physical_server_policy",
+      [
+        select(
+          :physical_server_lifecycle_choice,
+          "fa fa-recycle fa-lg",
+          t = N_("Lifecycle"),
+          t,
+          :enabled => true,
+          :items   => [
+            button(
+              :physical_server_provision,
+              "pficon pficon-add-circle-o fa-lg",
+              t = N_("Provision Physical Server"),
+              t,
+              :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck,
+              :data  => {
+                "function"      => "sendDataWithRx",
+                "function-data" => {
+                  :controller     => "provider_dialogs",
+                  :button         => :physical_server_provision,
+                  :modal_title    => N_("Provision Physical Server"),
+                  :component_name => "RedfishServerProvisionDialog",
+                }.to_json,
+              }
+            ),
+          ]
+        ),
+      ]
+    )
+  end
+end

--- a/app/helpers/manageiq/providers/redfish/toolbar_overrides/physical_servers_center.rb
+++ b/app/helpers/manageiq/providers/redfish/toolbar_overrides/physical_servers_center.rb
@@ -1,0 +1,37 @@
+module ManageIQ::Providers::Redfish
+  class ToolbarOverrides::PhysicalServersCenter \
+      < ::ApplicationHelper::Toolbar::Override
+    button_group(
+      "physical_server_policy",
+      [
+        select(
+          :physical_server_lifecycle_choice,
+          "fa fa-recycle fa-lg",
+          t = N_("Lifecycle"),
+          t,
+          :enabled => true,
+          :items   => [
+            button(
+              :physical_server_provision,
+              "pficon pficon-add-circle-o fa-lg",
+              t = N_("Provision Selected Physical Servers"),
+              t,
+              :klass   => ApplicationHelper::Button::ButtonWithoutRbacCheck,
+              :data    => {
+                "function"      => "sendDataWithRx",
+                "function-data" => {
+                  :controller     => "provider_dialogs",
+                  :button         => :physical_server_provision,
+                  :modal_title    => N_("Provision Selected Physical Servers"),
+                  :component_name => "RedfishServerProvisionDialog",
+                }.to_json,
+              },
+              :enabled => false,
+              :onwhen  => "1+"
+            ),
+          ]
+        ),
+      ]
+    )
+  end
+end

--- a/app/javascript/components/forms/pxe-details.jsx
+++ b/app/javascript/components/forms/pxe-details.jsx
@@ -1,0 +1,99 @@
+import React, { Component } from "react";
+import { Form, Field, FormSpy } from "react-final-form";
+import { Form as PfForm, Grid, Button, Col, Row, Spinner } from "patternfly-react";
+import PropTypes from "prop-types";
+import { required } from "redux-form-validators";
+
+import { FinalFormField, FinalFormSelect } from "@manageiq/react-ui-components/dist/forms";
+import '@manageiq/react-ui-components/dist/forms.css';
+
+const PxeDetails = ({loading, updateFormState, physicalServerIds, initialValues, pxeServers, pxeImages,
+                      customizationTemplates}) => {
+  if(loading){
+    return (
+      <Spinner loading size="lg" />
+    );
+  }
+
+  return (
+    <Form
+      onSubmit={() => {}} // handled by modal
+      initialValues={initialValues}
+      render={({ handleSubmit }) => (
+        <PfForm horizontal>
+          <FormSpy onChange={state => updateFormState({ ...state, values: state.values })} />
+          <Grid fluid>
+            <Row>
+              <Col xs={12}>
+                <h2>{__(`Number of servers to be provisioned: ${physicalServerIds.length}`)}</h2>
+              </Col>
+            </Row>
+            <hr />
+            <Row>
+              <Col xs={12}>
+                <Field
+                  name="pxeServer"
+                  component={FinalFormSelect}
+                  placeholder={__('Select a PXE Server')}
+                  options={pxeServers}
+                  label={__('PXE Server')}
+                  validateOnMount={false}
+                  validate={required({ msg: 'PXE Server is required' })}
+                  labelColumnSize={3}
+                  inputColumnSize={8}
+                  searchable
+                />
+              </Col>
+              <Col xs={12}>
+                <Field
+                  name="pxeImage"
+                  component={FinalFormSelect}
+                  placeholder={__('Select a PXE Image')}
+                  options={pxeImages}
+                  disabled={pxeImages.length === 0}
+                  label={__('PXE Image')}
+                  validateOnMount={false}
+                  validate={required({ msg: 'PXE Image is required' })}
+                  labelColumnSize={3}
+                  inputColumnSize={8}
+                  searchable
+                />
+              </Col>
+              <Col xs={12}>
+                <Field
+                  name="customizationTemplate"
+                  component={FinalFormSelect}
+                  placeholder={__('Select Customization Template')}
+                  options={customizationTemplates}
+                  disabled={customizationTemplates.length === 0}
+                  label={__('Customization Template')}
+                  validateOnMount={false}
+                  validate={required({ msg: 'Customization Template is required' })}
+                  labelColumnSize={3}
+                  inputColumnSize={8}
+                  searchable
+                />
+              </Col>
+              <hr />
+            </Row>
+          </Grid>
+        </PfForm>
+      )}
+    />
+  );
+};
+
+PxeDetails.propTypes = {
+  updateFormState: PropTypes.func.isRequired,
+  physicalServerIds: PropTypes.array.isRequired,
+  pxeServers: PropTypes.array.isRequired,
+  pxeImages: PropTypes.array.isRequired,
+  customizationTemplates: PropTypes.array.isRequired,
+  loading: PropTypes.bool.isRequired
+};
+
+PxeDetails.defaultProps = {
+  loading: false,
+};
+
+export default PxeDetails;

--- a/app/javascript/components/redfish-server-provision-dialog.jsx
+++ b/app/javascript/components/redfish-server-provision-dialog.jsx
@@ -1,0 +1,112 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import PxeDetails from "./forms/pxe-details"
+import { handleApiError, fetchPxeServers, fetchPxeImagesForServer, fetchTemplatesForPxeImage,
+  createProvisionRequest
+} from "../utils/api";
+
+class RedfishServerProvisionDialog extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleFormStateUpdate = this.handleFormStateUpdate.bind(this);
+    this.state = {
+      loading: true,
+      physicalServerIds: [],
+      pxeServers: [],
+      pxeImages: [],
+      customizationTemplates: [],
+    }
+  }
+
+  selectedPhysicalServers = () => {
+    if(ManageIQ.record.recordId){ // Single-record page
+      this.setState({physicalServerIds: [ManageIQ.record.recordId]});
+    } else if(ManageIQ.gridChecks.length > 0){ // Multi-record page
+      this.setState({physicalServerIds: ManageIQ.gridChecks});
+    } else{
+      this.setState({physicalServerIds: [], error: __('Please select at lest one physical server to provision.')});
+    }
+  };
+
+  pxeServerToSelectOption = pxeServer => { return { value: pxeServer.id, label: `${pxeServer.name} (${pxeServer.uri})` } };
+  pxeImageToSelectOption = pxeImage => { return { value: pxeImage.id, label: pxeImage.name } };
+  templateToSelectOption = template => { return { value: template.id, label: template.name } };
+
+  initializeData = () => fetchPxeServers().then((pxeServers) => {
+      this.setState({
+        pxeServers: pxeServers.resources.map(this.pxeServerToSelectOption),
+        loading: false
+      });
+    }, handleApiError(this));
+
+  onChange = (formState) => {
+    if(formState.modified.pxeServer){
+      this.setState({customizationTemplates: []});
+      fetchPxeImagesForServer(formState.values.pxeServer).then(images => {
+        this.setState({pxeImages: images.resources.map(this.pxeImageToSelectOption)});
+      }, handleApiError(this));
+    } else if(formState.modified.pxeImage){
+      fetchTemplatesForPxeImage(formState.values.pxeImage).then(templates => {
+        this.setState({customizationTemplates: templates.resources.map(this.templateToSelectOption)});
+      }, handleApiError(this));
+    }
+  };
+
+  componentDidMount() {
+    this.props.dispatch({
+      type: "FormButtons.init",
+      payload: {
+        newRecord: true,
+        pristine: true,
+        addClicked: () => createProvisionRequest(
+          this.state.physicalServerIds, this.state.values.pxeImage, this.state.values.customizationTemplate
+        )
+      }
+    });
+    this.props.dispatch({
+      type: "FormButtons.customLabel",
+      payload: __('Provision')
+    });
+    this.selectedPhysicalServers();
+    this.initializeData()
+  }
+
+  handleFormStateUpdate(formState) {
+    this.props.dispatch({
+      type: "FormButtons.saveable",
+      payload: formState.valid
+    });
+    this.props.dispatch({
+      type: "FormButtons.pristine",
+      payload: formState.pristine
+    });
+    this.setState({
+      values: formState.values
+    });
+    this.onChange(formState);
+  }
+
+  render() {
+    if(this.state.error) {
+      return <p>{this.state.error}</p>
+    }
+    return (
+      <PxeDetails
+        updateFormState={this.handleFormStateUpdate}
+        physicalServerIds={this.state.physicalServerIds}
+        pxeServers={this.state.pxeServers}
+        pxeImages={this.state.pxeImages}
+        customizationTemplates={this.state.customizationTemplates}
+        loading={this.state.loading}
+        initialValues={this.state.values}
+      />
+    );
+  }
+}
+
+RedfishServerProvisionDialog.propTypes = {
+  dispatch: PropTypes.func.isRequired,
+};
+
+export default connect()(RedfishServerProvisionDialog);

--- a/app/javascript/packs/component-definition-common.js
+++ b/app/javascript/packs/component-definition-common.js
@@ -1,0 +1,6 @@
+import RedfishServerProvisionDialog
+  from "../components/redfish-server-provision-dialog";
+
+ManageIQ.component.addReact(
+  "RedfishServerProvisionDialog", RedfishServerProvisionDialog
+);

--- a/app/javascript/utils/api.js
+++ b/app/javascript/utils/api.js
@@ -1,0 +1,29 @@
+export const fetchPxeServers = () => API.get(`/api/pxe_servers?expand=resources&attributes=id,name,uri`);
+
+export const fetchPxeImagesForServer = (serverId) => API.get(`/api/pxe_servers/${serverId}/pxe_images?expand=resources&attributes=id,name,pxe_image_type_id`);
+
+export const fetchTemplatesForPxeImage = (pxeImageId) => API.get(`/api/pxe_images/${pxeImageId}/customization_templates?expand=resources&attributes=id,name`);
+
+export const createProvisionRequest = (physicalServerIds, pxeImageId, templateId) => API.post(`/api/requests`, {
+  options: {
+    request_type: 'provision_physical_server',
+    src_ids: physicalServerIds,
+    pxe_image_id: pxeImageId,
+    customization_template_id: templateId
+  },
+  auto_approve: false
+}).then(response => {
+  response['results'].forEach(res => window.add_flash(res.message, res.status === 'Ok' ? 'success' : 'error'));
+});
+
+export const handleApiError = (self) => {
+  return (err) => {
+    let msg = __('Unknown API error');
+    if(err.data && err.data.error && err.data.error.message) {
+      msg = err.data.error.message
+    }
+    self.setState({loading: false, error: msg});
+  };
+};
+
+export const newApiLikeError = (msg) => { return { data: { error: { message: msg } } } };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "manageiq-providers-redfish",
+  "version": "1.0.0",
+  "description": "ManageIQ Redfish provider UI components",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ManageIQ/manageiq-providers-redfish.git"
+  },
+  "author": "ManageIQ",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/ManageIQ/manageiq-providers-redfish/issues"
+  },
+  "homepage": "https://github.com/ManageIQ/manageiq-providers-redfish#readme",
+  "dependencies": {
+    "@manageiq/react-ui-components": "~0.9.5",
+    "prop-types": "^15.6.0",
+    "react": "^16.3.1",
+    "react-dom": "^16.3.1",
+    "react-redux": "^5.0.7",
+    "redux": "^4.0.0"
+  },
+  "devDependencies": {
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-export-extensions": "^6.22.0",
+    "babel-plugin-transform-object-assign": "^6.8.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-preset-env": "^1.6.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-1": "^6.24.1",
+    "jest": "^23.4.2"
+  },
+  "engines": {
+    "node": ">= 6.9.1",
+    "npm": ">= 3.10.3",
+    "yarn": ">= 0.20.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -32,11 +32,28 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-1": "^6.24.1",
+    "enzyme": "^3.3.0",
+    "enzyme-adapter-react-16": "^1.1.1",
+    "enzyme-to-json": "^3.3.4",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^23.4.2"
   },
   "engines": {
     "node": ">= 6.9.1",
     "npm": ">= 3.10.3",
     "yarn": ">= 0.20.1"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "jest": {
+    "testURL": "http://localhost",
+    "setupTestFrameworkScriptFile": "<rootDir>/spec/javascript/setup.js",
+    "roots": [
+      "<rootDir>/spec/javascript"
+    ],
+    "moduleNameMapper": {
+      "\\.(css)$": "identity-obj-proxy"
+    }
   }
 }

--- a/spec/javascript/components/__snapshots__/redfish-server-provision-dialog.test.jsx.snap
+++ b/spec/javascript/components/__snapshots__/redfish-server-provision-dialog.test.jsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RedfishServerProvisionDialog componentDidMount fetchPxeServers fails 1`] = `
+<p>
+  MSG
+</p>
+`;
+
+exports[`RedfishServerProvisionDialog componentDidMount fetchPxeServers succeeds 1`] = `
+<PxeDetails
+  customizationTemplates={Array []}
+  loading={false}
+  physicalServerIds={
+    Array [
+      123,
+    ]
+  }
+  pxeImages={Array []}
+  pxeServers={
+    Array [
+      Object {
+        "label": "PXE1 (URI1)",
+        "value": 1,
+      },
+    ]
+  }
+  updateFormState={[Function]}
+/>
+`;

--- a/spec/javascript/components/forms/__snapshots__/pxe-details.test.jsx.snap
+++ b/spec/javascript/components/forms/__snapshots__/pxe-details.test.jsx.snap
@@ -1,0 +1,457 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PxeDetails renders form with pxe servers 1`] = `
+<Form
+  bsClass="form"
+  componentClass="form"
+  horizontal={true}
+  inline={false}
+>
+  <FormSpy
+    onChange={[Function]}
+  />
+  <Grid
+    bsClass="container"
+    componentClass="div"
+    fluid={true}
+  >
+    <Row
+      bsClass="row"
+      componentClass="div"
+    >
+      <Col
+        bsClass="col"
+        componentClass="div"
+        xs={12}
+      >
+        <h2>
+          _Number of servers to be provisioned: 3_
+        </h2>
+      </Col>
+    </Row>
+    <hr />
+    <Row
+      bsClass="row"
+      componentClass="div"
+    >
+      <Col
+        bsClass="col"
+        componentClass="div"
+        xs={12}
+      >
+        <Field
+          component={[Function]}
+          format={[Function]}
+          inputColumnSize={8}
+          label="_PXE Server_"
+          labelColumnSize={3}
+          name="pxeServer"
+          options={
+            Array [
+              Object {
+                "label": "PXE1",
+                "value": "pxe1",
+              },
+            ]
+          }
+          parse={[Function]}
+          placeholder="_Select a PXE Server_"
+          searchable={true}
+          validate={[Function]}
+          validateOnMount={false}
+        />
+      </Col>
+      <Col
+        bsClass="col"
+        componentClass="div"
+        xs={12}
+      >
+        <Field
+          component={[Function]}
+          disabled={true}
+          format={[Function]}
+          inputColumnSize={8}
+          label="_PXE Image_"
+          labelColumnSize={3}
+          name="pxeImage"
+          options={Array []}
+          parse={[Function]}
+          placeholder="_Select a PXE Image_"
+          searchable={true}
+          validate={[Function]}
+          validateOnMount={false}
+        />
+      </Col>
+      <Col
+        bsClass="col"
+        componentClass="div"
+        xs={12}
+      >
+        <Field
+          component={[Function]}
+          disabled={true}
+          format={[Function]}
+          inputColumnSize={8}
+          label="_Customization Template_"
+          labelColumnSize={3}
+          name="customizationTemplate"
+          options={Array []}
+          parse={[Function]}
+          placeholder="_Select Customization Template_"
+          searchable={true}
+          validate={[Function]}
+          validateOnMount={false}
+        />
+      </Col>
+      <hr />
+    </Row>
+  </Grid>
+</Form>
+`;
+
+exports[`PxeDetails renders form with pxe servers and pxe images 1`] = `
+<Form
+  bsClass="form"
+  componentClass="form"
+  horizontal={true}
+  inline={false}
+>
+  <FormSpy
+    onChange={[Function]}
+  />
+  <Grid
+    bsClass="container"
+    componentClass="div"
+    fluid={true}
+  >
+    <Row
+      bsClass="row"
+      componentClass="div"
+    >
+      <Col
+        bsClass="col"
+        componentClass="div"
+        xs={12}
+      >
+        <h2>
+          _Number of servers to be provisioned: 3_
+        </h2>
+      </Col>
+    </Row>
+    <hr />
+    <Row
+      bsClass="row"
+      componentClass="div"
+    >
+      <Col
+        bsClass="col"
+        componentClass="div"
+        xs={12}
+      >
+        <Field
+          component={[Function]}
+          format={[Function]}
+          inputColumnSize={8}
+          label="_PXE Server_"
+          labelColumnSize={3}
+          name="pxeServer"
+          options={
+            Array [
+              Object {
+                "label": "PXE1",
+                "value": "pxe1",
+              },
+            ]
+          }
+          parse={[Function]}
+          placeholder="_Select a PXE Server_"
+          searchable={true}
+          validate={[Function]}
+          validateOnMount={false}
+        />
+      </Col>
+      <Col
+        bsClass="col"
+        componentClass="div"
+        xs={12}
+      >
+        <Field
+          component={[Function]}
+          disabled={false}
+          format={[Function]}
+          inputColumnSize={8}
+          label="_PXE Image_"
+          labelColumnSize={3}
+          name="pxeImage"
+          options={
+            Array [
+              Object {
+                "label": "IMG1",
+                "value": "img1",
+              },
+            ]
+          }
+          parse={[Function]}
+          placeholder="_Select a PXE Image_"
+          searchable={true}
+          validate={[Function]}
+          validateOnMount={false}
+        />
+      </Col>
+      <Col
+        bsClass="col"
+        componentClass="div"
+        xs={12}
+      >
+        <Field
+          component={[Function]}
+          disabled={true}
+          format={[Function]}
+          inputColumnSize={8}
+          label="_Customization Template_"
+          labelColumnSize={3}
+          name="customizationTemplate"
+          options={Array []}
+          parse={[Function]}
+          placeholder="_Select Customization Template_"
+          searchable={true}
+          validate={[Function]}
+          validateOnMount={false}
+        />
+      </Col>
+      <hr />
+    </Row>
+  </Grid>
+</Form>
+`;
+
+exports[`PxeDetails renders form with pxe servers and pxe images and templates 1`] = `
+<Form
+  bsClass="form"
+  componentClass="form"
+  horizontal={true}
+  inline={false}
+>
+  <FormSpy
+    onChange={[Function]}
+  />
+  <Grid
+    bsClass="container"
+    componentClass="div"
+    fluid={true}
+  >
+    <Row
+      bsClass="row"
+      componentClass="div"
+    >
+      <Col
+        bsClass="col"
+        componentClass="div"
+        xs={12}
+      >
+        <h2>
+          _Number of servers to be provisioned: 3_
+        </h2>
+      </Col>
+    </Row>
+    <hr />
+    <Row
+      bsClass="row"
+      componentClass="div"
+    >
+      <Col
+        bsClass="col"
+        componentClass="div"
+        xs={12}
+      >
+        <Field
+          component={[Function]}
+          format={[Function]}
+          inputColumnSize={8}
+          label="_PXE Server_"
+          labelColumnSize={3}
+          name="pxeServer"
+          options={
+            Array [
+              Object {
+                "label": "PXE1",
+                "value": "pxe1",
+              },
+            ]
+          }
+          parse={[Function]}
+          placeholder="_Select a PXE Server_"
+          searchable={true}
+          validate={[Function]}
+          validateOnMount={false}
+        />
+      </Col>
+      <Col
+        bsClass="col"
+        componentClass="div"
+        xs={12}
+      >
+        <Field
+          component={[Function]}
+          disabled={false}
+          format={[Function]}
+          inputColumnSize={8}
+          label="_PXE Image_"
+          labelColumnSize={3}
+          name="pxeImage"
+          options={
+            Array [
+              Object {
+                "label": "IMG1",
+                "value": "img1",
+              },
+            ]
+          }
+          parse={[Function]}
+          placeholder="_Select a PXE Image_"
+          searchable={true}
+          validate={[Function]}
+          validateOnMount={false}
+        />
+      </Col>
+      <Col
+        bsClass="col"
+        componentClass="div"
+        xs={12}
+      >
+        <Field
+          component={[Function]}
+          disabled={false}
+          format={[Function]}
+          inputColumnSize={8}
+          label="_Customization Template_"
+          labelColumnSize={3}
+          name="customizationTemplate"
+          options={
+            Array [
+              Object {
+                "label": "TEMPL1",
+                "value": "templ1",
+              },
+            ]
+          }
+          parse={[Function]}
+          placeholder="_Select Customization Template_"
+          searchable={true}
+          validate={[Function]}
+          validateOnMount={false}
+        />
+      </Col>
+      <hr />
+    </Row>
+  </Grid>
+</Form>
+`;
+
+exports[`PxeDetails renders form without pxe servers 1`] = `
+<Form
+  bsClass="form"
+  componentClass="form"
+  horizontal={true}
+  inline={false}
+>
+  <FormSpy
+    onChange={[Function]}
+  />
+  <Grid
+    bsClass="container"
+    componentClass="div"
+    fluid={true}
+  >
+    <Row
+      bsClass="row"
+      componentClass="div"
+    >
+      <Col
+        bsClass="col"
+        componentClass="div"
+        xs={12}
+      >
+        <h2>
+          _Number of servers to be provisioned: 3_
+        </h2>
+      </Col>
+    </Row>
+    <hr />
+    <Row
+      bsClass="row"
+      componentClass="div"
+    >
+      <Col
+        bsClass="col"
+        componentClass="div"
+        xs={12}
+      >
+        <Field
+          component={[Function]}
+          format={[Function]}
+          inputColumnSize={8}
+          label="_PXE Server_"
+          labelColumnSize={3}
+          name="pxeServer"
+          options={Array []}
+          parse={[Function]}
+          placeholder="_Select a PXE Server_"
+          searchable={true}
+          validate={[Function]}
+          validateOnMount={false}
+        />
+      </Col>
+      <Col
+        bsClass="col"
+        componentClass="div"
+        xs={12}
+      >
+        <Field
+          component={[Function]}
+          disabled={true}
+          format={[Function]}
+          inputColumnSize={8}
+          label="_PXE Image_"
+          labelColumnSize={3}
+          name="pxeImage"
+          options={Array []}
+          parse={[Function]}
+          placeholder="_Select a PXE Image_"
+          searchable={true}
+          validate={[Function]}
+          validateOnMount={false}
+        />
+      </Col>
+      <Col
+        bsClass="col"
+        componentClass="div"
+        xs={12}
+      >
+        <Field
+          component={[Function]}
+          disabled={true}
+          format={[Function]}
+          inputColumnSize={8}
+          label="_Customization Template_"
+          labelColumnSize={3}
+          name="customizationTemplate"
+          options={Array []}
+          parse={[Function]}
+          placeholder="_Select Customization Template_"
+          searchable={true}
+          validate={[Function]}
+          validateOnMount={false}
+        />
+      </Col>
+      <hr />
+    </Row>
+  </Grid>
+</Form>
+`;
+
+exports[`PxeDetails renders spinner 1`] = `
+<div
+  className="spinner spinner-lg"
+/>
+`;

--- a/spec/javascript/components/forms/pxe-details.test.jsx
+++ b/spec/javascript/components/forms/pxe-details.test.jsx
@@ -1,0 +1,50 @@
+import PxeDetails from '../../../../app/javascript/components/forms/pxe-details'
+
+let renderComponent;
+let physicalServers = [1, 2, 3];
+let pxeServers = [{value: 'pxe1', label: 'PXE1'}];
+let pxeImages = [{value: 'img1', label: 'IMG1'}];
+let templates = [{value: 'templ1', label: 'TEMPL1'}];
+
+describe('PxeDetails', () => {
+  beforeAll(() => {
+    renderComponent = (loading = false, physicalServers = [], pxeServers = [], pxeImages = [], templates = []) => shallowRedux(
+      <PxeDetails
+        updateFormState={jest.fn()} loading={loading}
+        physicalServerIds={physicalServers}
+        pxeServers={pxeServers}
+        pxeImages={pxeImages}
+        customizationTemplates={templates}
+      />
+      );
+  });
+
+  describe('renders', () => {
+    it('spinner', () => {
+      let component = renderComponent(true);
+      expect(toJson(component)).toMatchSnapshot();
+    });
+
+    describe('form', () => {
+      it('without pxe servers', () => {
+        let component = renderComponent(false, physicalServers);
+        expect(toJson(component)).toMatchSnapshot();
+      });
+
+      it('with pxe servers', () => {
+        let component = renderComponent(false, physicalServers, pxeServers);
+        expect(toJson(component)).toMatchSnapshot();
+      });
+
+      it('with pxe servers and pxe images', () => {
+        let component = renderComponent(false, physicalServers, pxeServers, pxeImages);
+        expect(toJson(component)).toMatchSnapshot();
+      });
+
+      it('with pxe servers and pxe images and templates', () => {
+        let component = renderComponent(false, physicalServers, pxeServers, pxeImages, templates);
+        expect(toJson(component)).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/spec/javascript/components/redfish-server-provision-dialog.test.jsx
+++ b/spec/javascript/components/redfish-server-provision-dialog.test.jsx
@@ -1,0 +1,58 @@
+import RedfishServerProvisionDialog from '../../../app/javascript/components/redfish-server-provision-dialog'
+import * as api from '../../../app/javascript/utils/api';
+
+const fetchPxeServersMock = jest.spyOn(api, 'fetchPxeServers').mockResolvedValue({resources: []});
+const dispatchMock = jest.spyOn(DEFAULT_STORE, 'dispatch');
+
+let renderComponent;
+let renderComponentFull;
+
+describe('RedfishServerProvisionDialog', () => {
+  beforeAll(() => {
+    renderComponent = () => shallowRedux(<RedfishServerProvisionDialog />);
+    renderComponentFull = () => mountRedux(<RedfishServerProvisionDialog />);
+  });
+
+  beforeEach(() => {
+    ManageIQ.record.recordId = 123;
+  });
+
+  describe('componentDidMount', () => {
+    it('fetchPxeServers succeeds', () => {
+      fetchPxeServersMock.mockResolvedValue({resources: [{ id: 1, name: 'PXE1', uri: 'URI1' }]});
+      let component = renderComponent();
+      return fetchPxeServersMock().then(() => {
+        component.update();
+        expect(fetchPxeServersMock).toHaveBeenCalled();
+        expect(component.state().loading).toEqual(false);
+        expect(component.state().pxeServers).toEqual([{'label': 'PXE1 (URI1)', 'value': 1}]);
+        expect(toJson(component)).toMatchSnapshot();
+      });
+    });
+
+    it('fetchPxeServers fails', () => {
+      fetchPxeServersMock.mockRejectedValue({data: {error: { message: 'MSG'}}});
+      let component = renderComponent();
+      return fetchPxeServersMock().catch(() => {
+        component.update();
+        expect(fetchPxeServersMock).toHaveBeenCalled();
+        expect(component.state().loading).toEqual(false);
+        expect(component.state().error).toEqual('MSG');
+        expect(toJson(component)).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('redux bindings', () => {
+    it('when fully mounted', () => {
+      fetchPxeServersMock.mockResolvedValue({resources: []});
+      let component = renderComponentFull();
+      return fetchPxeServersMock().then(() => {
+        expect(dispatchMock).toHaveBeenCalledWith({type: 'FormButtons.init',        payload: expect.anything()});
+        expect(dispatchMock).toHaveBeenCalledWith({type: 'FormButtons.customLabel', payload: expect.anything()});
+        expect(dispatchMock).toHaveBeenCalledWith({type: 'FormButtons.saveable',    payload: expect.anything()});
+        expect(dispatchMock).toHaveBeenCalledWith({type: 'FormButtons.pristine',    payload: expect.anything()});
+      });
+    });
+  });
+});

--- a/spec/javascript/setup.js
+++ b/spec/javascript/setup.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import configureStore from 'redux-mock-store';
+import { shallow, mount } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+// Enzyme configuration and some utility functions.
+Enzyme.configure({ adapter: new Adapter() });
+global.shallowRedux = (component) => shallow(component, DEFAULT_CONTEXT).dive();
+global.mountRedux = (component) => mount(component, DEFAULT_CONTEXT);
+
+// Global variables that Components usually get from elsewhere.
+global.ManageIQ = { record: { recordId: -1 } };
+global.__ = jest.fn().mockImplementation((val) => `_${val}_`);
+
+// Redux store mocks.
+global.mockStore = configureStore();
+global.DEFAULT_STORE = mockStore({});
+global.DEFAULT_CONTEXT = { context: {store: DEFAULT_STORE} };
+
+// Make common functions available to all tests so we don't need to import every time.
+global.shallow = shallow;
+global.mount = mount;
+global.toJson = toJson;
+global.React = React;


### PR DESCRIPTION
With this commit we implement the UI for Redfish physical server provisioning. User is offered to pick PXE Image and Customization template. When she clicks "Provision" a Request is created for her where she can then track provisioning status.

![image](https://user-images.githubusercontent.com/8102426/56296182-4aa18500-612e-11e9-9b6b-801cef28f620.png)

![image](https://user-images.githubusercontent.com/8102426/56296241-61e07280-612e-11e9-8077-65c3cce881b1.png)

Depends on:
 - [x] https://github.com/ManageIQ/manageiq-api/pull/578

