### PR TITLE
Enable `with_provider_object` on PhysicalServer

### DIFF
--- a/app/models/manageiq/providers/redfish/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager.rb
@@ -4,6 +4,7 @@ module ManageIQ::Providers::Redfish
     require_nested :EventParser
     require_nested :Refresher
     require_nested :RefreshWorker
+    require_nested :PhysicalServer
 
     include Vmdb::Logging
     include ManagerMixin

--- a/app/models/manageiq/providers/redfish/physical_infra_manager/physical_server.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager/physical_server.rb
@@ -3,5 +3,9 @@ module ManageIQ::Providers::Redfish
     def self.display_name(number = 1)
       n_('Physical Server (Redfish)', 'Physical Servers (Redfish)', number)
     end
+
+    def provider_object(connection)
+      connection.find(ems_ref)
+    end
   end
 end

--- a/spec/factories/physical_server.rb
+++ b/spec/factories/physical_server.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
           :class  => "ManageIQ::Providers::Redfish::PhysicalInfraManager::PhysicalServer",
           :parent => :physical_server do
     trait :vcr do
-      ems_ref { "/redfish/v1/Systems/System.Embedded.1" }
+      ems_ref { "/redfish/v1/Systems/System-1-1-1-1" }
     end
   end
 end

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/physical_server_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/physical_server_spec.rb
@@ -1,0 +1,19 @@
+describe ManageIQ::Providers::Redfish::PhysicalInfraManager::PhysicalServer do
+  subject { FactoryBot.create(:redfish_physical_server, :vcr, :ext_management_system => ems) }
+
+  let(:ems) { FactoryBot.create(:ems_redfish_physical_infra, :vcr) }
+
+  it '.display_name' do
+    expect(described_class).to receive(:n_).with('Physical Server (Redfish)', 'Physical Servers (Redfish)', 1)
+    described_class.display_name
+  end
+
+  describe '#with_provider_object', :vcr do
+    it 'yields correct system' do
+      subject.with_provider_object do |system|
+        expect(system).not_to be_nil
+        expect(subject.ems_ref).to match(".+/#{system.Id}")
+      end
+    end
+  end
+end

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_blink_loc_led/makes_location_LED_start_blinking.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_blink_loc_led/makes_location_LED_start_blinking.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
@@ -21,9 +21,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:11 GMT
+      - Fri, 19 Apr 2019 08:04:58 GMT
       Content-Length:
       - '362'
       Connection:
@@ -33,7 +33,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
         Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:11 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:58 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
@@ -42,7 +42,7 @@ http_interactions:
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
@@ -57,44 +57,83 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - e833eb2f-2923-48cb-acc6-e75de6352477
+      - ec49a5ac-796c-4540-bb65-f7eb178ec6d0
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:11 GMT
+      - Fri, 19 Apr 2019 08:04:58 GMT
       Content-Length:
-      - '253'
+      - '256'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/e833eb2f-2923-48cb-acc6-e75de6352477","Id":"e833eb2f-2923-48cb-acc6-e75de6352477","Name":"e833eb2f-2923-48cb-acc6-e75de6352477","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/ec49a5ac-796c-4540-bb65-f7eb178ec6d0","Id":"ec49a5ac-796c-4540-bb65-f7eb178ec6d0","Name":"ec49a5ac-796c-4540-bb65-f7eb178ec6d0","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:11 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:58 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - e833eb2f-2923-48cb-acc6-e75de6352477
+      - ec49a5ac-796c-4540-bb65-f7eb178ec6d0
   response:
     status:
-      code: 404
-      message: 'Not Found '
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      Date:
+      - Fri, 19 Apr 2019 08:04:58 GMT
+      Content-Length:
+      - '984'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Description":"G5
+        Computer System Node","Id":"System-1-1-1-1","IndicatorLED":"Off","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
+        Computer System","PowerState":"PoweringOn","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
+    http_version: 
+  recorded_at: Fri, 19 Apr 2019 08:04:58 GMT
+- request:
+    method: patch
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
+    body:
+      encoding: UTF-8
+      string: '{"IndicatorLED":"Blinking"}'
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - ec49a5ac-796c-4540-bb65-f7eb178ec6d0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 501
+      message: 'Not Implemented '
     headers:
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:11 GMT
+      - Fri, 19 Apr 2019 08:04:58 GMT
       Content-Length:
       - '0'
       Connection:
@@ -103,36 +142,36 @@ http_interactions:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:11 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:58 GMT
 - request:
     method: delete
-    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/e833eb2f-2923-48cb-acc6-e75de6352477
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/ec49a5ac-796c-4540-bb65-f7eb178ec6d0
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - e833eb2f-2923-48cb-acc6-e75de6352477
+      - ec49a5ac-796c-4540-bb65-f7eb178ec6d0
   response:
     status:
       code: 204
       message: 'No Content '
     headers:
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:11 GMT
+      - Fri, 19 Apr 2019 08:04:58 GMT
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:11 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:58 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_off/powers_off_the_system.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_off/powers_off_the_system.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
@@ -21,9 +21,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:06 GMT
+      - Fri, 19 Apr 2019 08:04:56 GMT
       Content-Length:
       - '362'
       Connection:
@@ -33,7 +33,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
         Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:06 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
@@ -42,7 +42,7 @@ http_interactions:
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
@@ -57,82 +57,136 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - 1e11625c-91b1-4440-9141-dff808551f8d
+      - 9f5b1717-6e4a-4a6f-95ac-7f07973ccfdd
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:06 GMT
+      - Fri, 19 Apr 2019 08:04:57 GMT
       Content-Length:
-      - '253'
+      - '256'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/1e11625c-91b1-4440-9141-dff808551f8d","Id":"1e11625c-91b1-4440-9141-dff808551f8d","Name":"1e11625c-91b1-4440-9141-dff808551f8d","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/9f5b1717-6e4a-4a6f-95ac-7f07973ccfdd","Id":"9f5b1717-6e4a-4a6f-95ac-7f07973ccfdd","Name":"9f5b1717-6e4a-4a6f-95ac-7f07973ccfdd","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:06 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 1e11625c-91b1-4440-9141-dff808551f8d
+      - 9f5b1717-6e4a-4a6f-95ac-7f07973ccfdd
   response:
     status:
-      code: 404
-      message: 'Not Found '
+      code: 200
+      message: 'OK '
     headers:
+      Content-Type:
+      - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:06 GMT
+      - Fri, 19 Apr 2019 08:04:57 GMT
       Content-Length:
-      - '0'
+      - '984'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: ''
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Description":"G5
+        Computer System Node","Id":"System-1-1-1-1","IndicatorLED":"Off","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
+        Computer System","PowerState":"PoweringOn","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:06 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
 - request:
-    method: delete
-    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/1e11625c-91b1-4440-9141-dff808551f8d
+    method: post
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: '{"ResetType":"GracefulShutdown"}'
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 1e11625c-91b1-4440-9141-dff808551f8d
+      - 9f5b1717-6e4a-4a6f-95ac-7f07973ccfdd
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 500
+      message: 'Internal Server Error '
+    headers:
+      Content-Type:
+      - text/html; charset=ISO-8859-1
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      Date:
+      - Fri, 19 Apr 2019 08:04:57 GMT
+      Content-Length:
+      - '335'
+      Connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+        <HTML>
+          <HEAD><TITLE>Internal Server Error</TITLE></HEAD>
+          <BODY>
+            <H1>Internal Server Error</H1>
+            undefined method `key?' for nil:NilClass
+            <HR>
+            <ADDRESS>
+             WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g at
+             REDFISH_HOST:8889
+            </ADDRESS>
+          </BODY>
+        </HTML>
+    http_version: 
+  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+- request:
+    method: delete
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/9f5b1717-6e4a-4a6f-95ac-7f07973ccfdd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 9f5b1717-6e4a-4a6f-95ac-7f07973ccfdd
   response:
     status:
       code: 204
       message: 'No Content '
     headers:
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:06 GMT
+      - Fri, 19 Apr 2019 08:04:57 GMT
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:06 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_off_now/powers_off_the_system_immediately.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_off_now/powers_off_the_system_immediately.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
@@ -21,9 +21,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:06 GMT
+      - Fri, 19 Apr 2019 08:04:56 GMT
       Content-Length:
       - '362'
       Connection:
@@ -33,7 +33,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
         Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:06 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:56 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
@@ -42,7 +42,7 @@ http_interactions:
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
@@ -57,82 +57,136 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - 471b4ee0-4c6c-4f47-8018-1ea3b6b58394
+      - 8fdef912-85db-4cbf-95c0-09c4610387fa
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:06 GMT
+      - Fri, 19 Apr 2019 08:04:56 GMT
       Content-Length:
-      - '253'
+      - '256'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/471b4ee0-4c6c-4f47-8018-1ea3b6b58394","Id":"471b4ee0-4c6c-4f47-8018-1ea3b6b58394","Name":"471b4ee0-4c6c-4f47-8018-1ea3b6b58394","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/8fdef912-85db-4cbf-95c0-09c4610387fa","Id":"8fdef912-85db-4cbf-95c0-09c4610387fa","Name":"8fdef912-85db-4cbf-95c0-09c4610387fa","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:06 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:56 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 471b4ee0-4c6c-4f47-8018-1ea3b6b58394
+      - 8fdef912-85db-4cbf-95c0-09c4610387fa
   response:
     status:
-      code: 404
-      message: 'Not Found '
+      code: 200
+      message: 'OK '
     headers:
+      Content-Type:
+      - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:06 GMT
+      - Fri, 19 Apr 2019 08:04:56 GMT
       Content-Length:
-      - '0'
+      - '984'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: ''
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Description":"G5
+        Computer System Node","Id":"System-1-1-1-1","IndicatorLED":"Off","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
+        Computer System","PowerState":"PoweringOn","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:06 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:56 GMT
 - request:
-    method: delete
-    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/471b4ee0-4c6c-4f47-8018-1ea3b6b58394
+    method: post
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: '{"ResetType":"ForceOff"}'
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 471b4ee0-4c6c-4f47-8018-1ea3b6b58394
+      - 8fdef912-85db-4cbf-95c0-09c4610387fa
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 500
+      message: 'Internal Server Error '
+    headers:
+      Content-Type:
+      - text/html; charset=ISO-8859-1
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      Date:
+      - Fri, 19 Apr 2019 08:04:56 GMT
+      Content-Length:
+      - '335'
+      Connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+        <HTML>
+          <HEAD><TITLE>Internal Server Error</TITLE></HEAD>
+          <BODY>
+            <H1>Internal Server Error</H1>
+            undefined method `key?' for nil:NilClass
+            <HR>
+            <ADDRESS>
+             WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g at
+             REDFISH_HOST:8889
+            </ADDRESS>
+          </BODY>
+        </HTML>
+    http_version: 
+  recorded_at: Fri, 19 Apr 2019 08:04:56 GMT
+- request:
+    method: delete
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/8fdef912-85db-4cbf-95c0-09c4610387fa
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 8fdef912-85db-4cbf-95c0-09c4610387fa
   response:
     status:
       code: 204
       message: 'No Content '
     headers:
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:06 GMT
+      - Fri, 19 Apr 2019 08:04:56 GMT
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:06 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:56 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_restart/restarts_the_system.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_restart/restarts_the_system.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
@@ -21,9 +21,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:06 GMT
+      - Fri, 19 Apr 2019 08:04:57 GMT
       Content-Length:
       - '362'
       Connection:
@@ -33,7 +33,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
         Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:06 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
@@ -42,7 +42,7 @@ http_interactions:
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
@@ -57,82 +57,136 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - 3fad8fb5-366a-4f7c-b83a-bd9e5a251e22
+      - 3f6dbce1-4b0e-4a2f-ab34-f4265b763ca0
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:06 GMT
+      - Fri, 19 Apr 2019 08:04:57 GMT
       Content-Length:
-      - '253'
+      - '256'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/3fad8fb5-366a-4f7c-b83a-bd9e5a251e22","Id":"3fad8fb5-366a-4f7c-b83a-bd9e5a251e22","Name":"3fad8fb5-366a-4f7c-b83a-bd9e5a251e22","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/3f6dbce1-4b0e-4a2f-ab34-f4265b763ca0","Id":"3f6dbce1-4b0e-4a2f-ab34-f4265b763ca0","Name":"3f6dbce1-4b0e-4a2f-ab34-f4265b763ca0","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:06 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 3fad8fb5-366a-4f7c-b83a-bd9e5a251e22
+      - 3f6dbce1-4b0e-4a2f-ab34-f4265b763ca0
   response:
     status:
-      code: 404
-      message: 'Not Found '
+      code: 200
+      message: 'OK '
     headers:
+      Content-Type:
+      - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:06 GMT
+      - Fri, 19 Apr 2019 08:04:57 GMT
       Content-Length:
-      - '0'
+      - '984'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: ''
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Description":"G5
+        Computer System Node","Id":"System-1-1-1-1","IndicatorLED":"Off","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
+        Computer System","PowerState":"PoweringOn","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:06 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
 - request:
-    method: delete
-    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/3fad8fb5-366a-4f7c-b83a-bd9e5a251e22
+    method: post
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: '{"ResetType":"GracefulRestart"}'
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 3fad8fb5-366a-4f7c-b83a-bd9e5a251e22
+      - 3f6dbce1-4b0e-4a2f-ab34-f4265b763ca0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 500
+      message: 'Internal Server Error '
+    headers:
+      Content-Type:
+      - text/html; charset=ISO-8859-1
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      Date:
+      - Fri, 19 Apr 2019 08:04:57 GMT
+      Content-Length:
+      - '335'
+      Connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+        <HTML>
+          <HEAD><TITLE>Internal Server Error</TITLE></HEAD>
+          <BODY>
+            <H1>Internal Server Error</H1>
+            undefined method `key?' for nil:NilClass
+            <HR>
+            <ADDRESS>
+             WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g at
+             REDFISH_HOST:8889
+            </ADDRESS>
+          </BODY>
+        </HTML>
+    http_version: 
+  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+- request:
+    method: delete
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/3f6dbce1-4b0e-4a2f-ab34-f4265b763ca0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 3f6dbce1-4b0e-4a2f-ab34-f4265b763ca0
   response:
     status:
       code: 204
       message: 'No Content '
     headers:
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:06 GMT
+      - Fri, 19 Apr 2019 08:04:57 GMT
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:06 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_restart_now/restarts_the_system_immediately.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_restart_now/restarts_the_system_immediately.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
@@ -21,9 +21,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:06 GMT
+      - Fri, 19 Apr 2019 08:04:57 GMT
       Content-Length:
       - '362'
       Connection:
@@ -33,7 +33,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
         Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:06 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
@@ -42,7 +42,7 @@ http_interactions:
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
@@ -57,82 +57,136 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - 0b5f85c4-738e-4611-9e76-a7a2f19b36b2
+      - 30263ba4-847c-4422-b4ab-5b7e2f15aa97
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:06 GMT
+      - Fri, 19 Apr 2019 08:04:57 GMT
       Content-Length:
-      - '253'
+      - '256'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/0b5f85c4-738e-4611-9e76-a7a2f19b36b2","Id":"0b5f85c4-738e-4611-9e76-a7a2f19b36b2","Name":"0b5f85c4-738e-4611-9e76-a7a2f19b36b2","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/30263ba4-847c-4422-b4ab-5b7e2f15aa97","Id":"30263ba4-847c-4422-b4ab-5b7e2f15aa97","Name":"30263ba4-847c-4422-b4ab-5b7e2f15aa97","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:06 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 0b5f85c4-738e-4611-9e76-a7a2f19b36b2
+      - 30263ba4-847c-4422-b4ab-5b7e2f15aa97
   response:
     status:
-      code: 404
-      message: 'Not Found '
+      code: 200
+      message: 'OK '
     headers:
+      Content-Type:
+      - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:06 GMT
+      - Fri, 19 Apr 2019 08:04:57 GMT
       Content-Length:
-      - '0'
+      - '984'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: ''
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Description":"G5
+        Computer System Node","Id":"System-1-1-1-1","IndicatorLED":"Off","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
+        Computer System","PowerState":"PoweringOn","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:06 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
 - request:
-    method: delete
-    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/0b5f85c4-738e-4611-9e76-a7a2f19b36b2
+    method: post
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: '{"ResetType":"ForceRestart"}'
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 0b5f85c4-738e-4611-9e76-a7a2f19b36b2
+      - 30263ba4-847c-4422-b4ab-5b7e2f15aa97
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 500
+      message: 'Internal Server Error '
+    headers:
+      Content-Type:
+      - text/html; charset=ISO-8859-1
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      Date:
+      - Fri, 19 Apr 2019 08:04:57 GMT
+      Content-Length:
+      - '335'
+      Connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+        <HTML>
+          <HEAD><TITLE>Internal Server Error</TITLE></HEAD>
+          <BODY>
+            <H1>Internal Server Error</H1>
+            undefined method `key?' for nil:NilClass
+            <HR>
+            <ADDRESS>
+             WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g at
+             REDFISH_HOST:8889
+            </ADDRESS>
+          </BODY>
+        </HTML>
+    http_version: 
+  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+- request:
+    method: delete
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/30263ba4-847c-4422-b4ab-5b7e2f15aa97
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 30263ba4-847c-4422-b4ab-5b7e2f15aa97
   response:
     status:
       code: 204
       message: 'No Content '
     headers:
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:07 GMT
+      - Fri, 19 Apr 2019 08:04:57 GMT
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:07 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_turn_off_loc_led/turns_off_location_LED.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_turn_off_loc_led/turns_off_location_LED.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
@@ -21,9 +21,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:11 GMT
+      - Fri, 19 Apr 2019 08:04:58 GMT
       Content-Length:
       - '362'
       Connection:
@@ -33,7 +33,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
         Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:11 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:58 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
@@ -42,7 +42,7 @@ http_interactions:
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
@@ -57,44 +57,83 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - 3e6a0694-888b-4924-a986-973e8b485160
+      - e0484ab4-3a49-4555-8a41-28edbec86ba9
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:11 GMT
+      - Fri, 19 Apr 2019 08:04:58 GMT
       Content-Length:
-      - '253'
+      - '256'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/3e6a0694-888b-4924-a986-973e8b485160","Id":"3e6a0694-888b-4924-a986-973e8b485160","Name":"3e6a0694-888b-4924-a986-973e8b485160","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/e0484ab4-3a49-4555-8a41-28edbec86ba9","Id":"e0484ab4-3a49-4555-8a41-28edbec86ba9","Name":"e0484ab4-3a49-4555-8a41-28edbec86ba9","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:11 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:58 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 3e6a0694-888b-4924-a986-973e8b485160
+      - e0484ab4-3a49-4555-8a41-28edbec86ba9
   response:
     status:
-      code: 404
-      message: 'Not Found '
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      Date:
+      - Fri, 19 Apr 2019 08:04:58 GMT
+      Content-Length:
+      - '984'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Description":"G5
+        Computer System Node","Id":"System-1-1-1-1","IndicatorLED":"Off","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
+        Computer System","PowerState":"PoweringOn","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
+    http_version: 
+  recorded_at: Fri, 19 Apr 2019 08:04:58 GMT
+- request:
+    method: patch
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
+    body:
+      encoding: UTF-8
+      string: '{"IndicatorLED":"Off"}'
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - e0484ab4-3a49-4555-8a41-28edbec86ba9
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 501
+      message: 'Not Implemented '
     headers:
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:11 GMT
+      - Fri, 19 Apr 2019 08:04:58 GMT
       Content-Length:
       - '0'
       Connection:
@@ -103,36 +142,36 @@ http_interactions:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:11 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:58 GMT
 - request:
     method: delete
-    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/3e6a0694-888b-4924-a986-973e8b485160
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/e0484ab4-3a49-4555-8a41-28edbec86ba9
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 3e6a0694-888b-4924-a986-973e8b485160
+      - e0484ab4-3a49-4555-8a41-28edbec86ba9
   response:
     status:
       code: 204
       message: 'No Content '
     headers:
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:11 GMT
+      - Fri, 19 Apr 2019 08:04:58 GMT
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:11 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:58 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_turn_on_loc_led/turns_on_location_LED.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_turn_on_loc_led/turns_on_location_LED.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
@@ -21,9 +21,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:11 GMT
+      - Fri, 19 Apr 2019 08:04:58 GMT
       Content-Length:
       - '362'
       Connection:
@@ -33,7 +33,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
         Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:11 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:58 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
@@ -42,7 +42,7 @@ http_interactions:
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
@@ -57,44 +57,83 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - c2910924-0ea6-406d-a06c-9661e2efd57b
+      - 3500746e-9e39-416e-915a-5426abf317fa
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:11 GMT
+      - Fri, 19 Apr 2019 08:04:58 GMT
       Content-Length:
-      - '253'
+      - '256'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/c2910924-0ea6-406d-a06c-9661e2efd57b","Id":"c2910924-0ea6-406d-a06c-9661e2efd57b","Name":"c2910924-0ea6-406d-a06c-9661e2efd57b","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/3500746e-9e39-416e-915a-5426abf317fa","Id":"3500746e-9e39-416e-915a-5426abf317fa","Name":"3500746e-9e39-416e-915a-5426abf317fa","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:11 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:58 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System.Embedded.1
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - c2910924-0ea6-406d-a06c-9661e2efd57b
+      - 3500746e-9e39-416e-915a-5426abf317fa
   response:
     status:
-      code: 404
-      message: 'Not Found '
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      Date:
+      - Fri, 19 Apr 2019 08:04:58 GMT
+      Content-Length:
+      - '984'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Description":"G5
+        Computer System Node","Id":"System-1-1-1-1","IndicatorLED":"Off","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
+        Computer System","PowerState":"PoweringOn","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
+    http_version: 
+  recorded_at: Fri, 19 Apr 2019 08:04:58 GMT
+- request:
+    method: patch
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
+    body:
+      encoding: UTF-8
+      string: '{"IndicatorLED":"Lit"}'
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 3500746e-9e39-416e-915a-5426abf317fa
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 501
+      message: 'Not Implemented '
     headers:
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:11 GMT
+      - Fri, 19 Apr 2019 08:04:58 GMT
       Content-Length:
       - '0'
       Connection:
@@ -103,36 +142,36 @@ http_interactions:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:11 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:58 GMT
 - request:
     method: delete
-    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/c2910924-0ea6-406d-a06c-9661e2efd57b
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/3500746e-9e39-416e-915a-5426abf317fa
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - c2910924-0ea6-406d-a06c-9661e2efd57b
+      - 3500746e-9e39-416e-915a-5426abf317fa
   response:
     status:
       code: 204
       message: 'No Content '
     headers:
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Mon, 24 Sep 2018 20:54:11 GMT
+      - Fri, 19 Apr 2019 08:04:58 GMT
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:11 GMT
+  recorded_at: Fri, 19 Apr 2019 08:04:58 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager_PhysicalServer/_with_provider_object/yields_correct_system.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager_PhysicalServer/_with_provider_object/yields_correct_system.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Fri, 19 Apr 2019 08:15:52 GMT
       Content-Length:
       - '362'
       Connection:
@@ -33,7 +33,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
         Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Fri, 19 Apr 2019 08:15:52 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
@@ -57,20 +57,20 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - 032d2c4e-a30f-430c-98ce-5da08d9dac55
+      - 8325d14d-83b2-432c-bc9b-509ccd8452d5
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Fri, 19 Apr 2019 08:15:52 GMT
       Content-Length:
       - '256'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/032d2c4e-a30f-430c-98ce-5da08d9dac55","Id":"032d2c4e-a30f-430c-98ce-5da08d9dac55","Name":"032d2c4e-a30f-430c-98ce-5da08d9dac55","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/8325d14d-83b2-432c-bc9b-509ccd8452d5","Id":"8325d14d-83b2-432c-bc9b-509ccd8452d5","Name":"8325d14d-83b2-432c-bc9b-509ccd8452d5","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Fri, 19 Apr 2019 08:15:52 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
@@ -85,7 +85,7 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 032d2c4e-a30f-430c-98ce-5da08d9dac55
+      - 8325d14d-83b2-432c-bc9b-509ccd8452d5
   response:
     status:
       code: 200
@@ -96,7 +96,7 @@ http_interactions:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Fri, 19 Apr 2019 08:15:52 GMT
       Content-Length:
       - '984'
       Connection:
@@ -107,60 +107,10 @@ http_interactions:
         Computer System Node","Id":"System-1-1-1-1","IndicatorLED":"Off","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
         Computer System","PowerState":"PoweringOn","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
-- request:
-    method: post
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset
-    body:
-      encoding: UTF-8
-      string: '{"ResetType":"On"}'
-    headers:
-      User-Agent:
-      - excon/0.64.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - 032d2c4e-a30f-430c-98ce-5da08d9dac55
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 500
-      message: 'Internal Server Error '
-    headers:
-      Content-Type:
-      - text/html; charset=ISO-8859-1
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
-      Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
-      Content-Length:
-      - '335'
-      Connection:
-      - close
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
-        <HTML>
-          <HEAD><TITLE>Internal Server Error</TITLE></HEAD>
-          <BODY>
-            <H1>Internal Server Error</H1>
-            undefined method `key?' for nil:NilClass
-            <HR>
-            <ADDRESS>
-             WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g at
-             REDFISH_HOST:8889
-            </ADDRESS>
-          </BODY>
-        </HTML>
-    http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Fri, 19 Apr 2019 08:15:52 GMT
 - request:
     method: delete
-    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/032d2c4e-a30f-430c-98ce-5da08d9dac55
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/8325d14d-83b2-432c-bc9b-509ccd8452d5
     body:
       encoding: US-ASCII
       string: ''
@@ -172,7 +122,7 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 032d2c4e-a30f-430c-98ce-5da08d9dac55
+      - 8325d14d-83b2-432c-bc9b-509ccd8452d5
   response:
     status:
       code: 204
@@ -181,12 +131,12 @@ http_interactions:
       Server:
       - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Fri, 19 Apr 2019 08:15:52 GMT
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Fri, 19 Apr 2019 08:15:52 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
With this commit we realize `provider_object` method on PhysicalServer to enable `with_provider_object` utility. Then we provide VCR test for it; and update some obsolete VCR cassettes down the way (they were using incorrect IDs from the mock server).

Depends on: https://github.com/ManageIQ/manageiq/pull/18668