### PR TITLE
Assign a more meaningful name for resources

### DIFF
--- a/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
@@ -21,7 +21,7 @@ module ManageIQ::Providers::Redfish
           :ems_ref          => s["@odata.id"],
           :health_state     => s.Status.Health,
           :hostname         => s.HostName,
-          :name             => s.Id,
+          :name             => resource_name(s),
           :physical_chassis => chassis,
           :physical_rack    => rack,
           :power_state      => s.PowerState,
@@ -30,6 +30,14 @@ module ManageIQ::Providers::Redfish
         )
         persister.computer_systems.build(:managed_entity => server)
       end
+    end
+
+    def resource_name(res)
+      parts = []
+      parts << res.Manufacturer if res.Manufacturer
+      parts << res.Name if res.Name
+      parts << "(#{res.SerialNumber})" if res.SerialNumber
+      parts.join(" ")
     end
 
     def physical_server_details
@@ -130,7 +138,7 @@ module ManageIQ::Providers::Redfish
         persister.physical_chassis.build(
           :ems_ref                 => c["@odata.id"],
           :health_state            => c.Status.Health,
-          :name                    => c.Id,
+          :name                    => resource_name(c),
           :parent_physical_chassis => chassis,
           :physical_rack           => rack,
         )

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
@@ -10,7 +10,7 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
       "/redfish/v1/Systems/System-1-1-1-1" => {
         :server       => {
           :health_state    => "OK",
-          :name            => "System-1-1-1-1",
+          :name            => "Dell G5 Computer System (CN701636AB0013)",
           :power_state     => "PoweringOn",
           :raw_power_state => "PoweringOn",
         },
@@ -34,7 +34,7 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
         :server       => {
           :health_state    => "Critical",
           :hostname        => "hostname.example.com",
-          :name            => "System-1-2-1-1",
+          :name            => "Dell Inc. System (945hjf0927mf)",
           :power_state     => "On",
           :raw_power_state => "On",
         },
@@ -67,7 +67,7 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
       "/redfish/v1/Chassis/Block-1-1"  => {
         :chassis      => {
           :health_state => "OK",
-          :name         => "Block-1-1",
+          :name         => "Dell G5_Block (11)",
         },
         :asset_detail => {
           :description        => "G5 Block Chassis",
@@ -84,7 +84,7 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
       "/redfish/v1/Chassis/Sled-1-1-1" => {
         :chassis      => {
           :health_state => "Warning",
-          :name         => "Sled-1-1-1",
+          :name         => "Dell G5_Sled (h894hf5n926h)",
         },
         :asset_detail => {
           :description        => "G5 Sled-Level Enclosure",


### PR DESCRIPTION
With this commit we concat couple of attributes of a resource to build a more meaningful name than the ems_ref itself.

This is a continuation of what @tadeboro implemented hence I listed him as the first author of the commit using 'Signed-off-by'.