### PR TITLE
Be super patient and nice when rebooting server

### DIFF
--- a/app/models/manageiq/providers/redfish/physical_infra_manager/physical_server/provisioning.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager/physical_server/provisioning.rb
@@ -8,7 +8,7 @@ module ManageIQ::Providers::Redfish
       end
     end
 
-    def reboot_using_pxe
+    def next_boot_using_pxe
       with_provider_object do |system|
         response = system.patch(
           :payload => {
@@ -20,14 +20,18 @@ module ManageIQ::Providers::Redfish
         )
         raise MiqException::MiqProvisionError, "Cannot override boot order: #{response.data[:body]}" if response.status >= 400
       end
-      # TODO: we perform force reboot which will fail in some cases. Need to handle with supports mixin.
-      restart_now
     end
 
     def powered_on_now?
-      # TODO(miha-plesko): we should rely on VMDB state instead contacting provider.
-      # Update implementation once we have event-driven targeted refresh implemented.
-      with_provider_object { |system| system.PowerState.to_s.downcase == 'on' }
+      power_state_now == "on"
+    end
+
+    def powered_off_now?
+      power_state_now == "off"
+    end
+
+    def power_state_now
+      with_provider_object { |system| system.PowerState.downcase }
     end
 
     private

--- a/app/models/manageiq/providers/redfish/physical_infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager/provision/state_machine.rb
@@ -1,4 +1,25 @@
 module ManageIQ::Providers::Redfish::PhysicalInfraManager::Provision::StateMachine
+  # This state machine does the following things:
+  #
+  #  1. Validate input parameters and configure components involved in the
+  #     provisioning process (PXE server, computer system).
+  #  2. Power cycle the computer system.
+  #
+  # Powering cycling the system is quite a complex operation, because it is
+  # heavily dependent on the current state of the system. The worst case
+  # scenario is when we get the system in PoweringOn state, since we need to
+  # wait for it to finish the boot process, then power it down and start it
+  # again. Steps taken in this worst-case scenario are:
+  #
+  #  1. Wait for server to transition into "On" state.
+  #  2. Trigger power off.
+  #  3. Wait for server to transition into "Off" state.
+  #  4. Trigger power on.
+  #  5. Wait for server to transition into "On" state.
+  #
+  # All other scenarios can be supported by simply skipping some of the
+  # initial steps from this list.
+
   def start_provisioning
     update_and_notify_parent(:message => msg('start provisioning'))
     signal :deploy_pxe_config
@@ -12,17 +33,47 @@ module ManageIQ::Providers::Redfish::PhysicalInfraManager::Provision::StateMachi
     unless (template = CustomizationTemplate.find_by(:id => options[:customization_template_id]))
       raise MiqException::MiqProvisionError, "CustomizationTemplate with id #{options[:customization_template_id]} not found"
     end
+
     source.deploy_pxe_config(pxe_image, template)
-    signal :reboot_using_pxe
+    source.next_boot_using_pxe
+
+    case power_state = source.power_state_now
+    when "poweringon"  then signal :poll_server_on_initial
+    when "on"          then signal :power_off_server
+    when "poweringoff" then signal :poll_server_off
+    when "off"         then signal :power_on_server
+    else raise MiqException::MiqProvisionError, "Unexpected server power state: #{power_state}"
+    end
   end
 
-  def reboot_using_pxe
-    update_and_notify_parent(:message => msg('reboot using PXE'))
-    source.reboot_using_pxe
-    signal :poll_server_running
+  def poll_server_on_initial
+    if source.powered_on_now?
+      signal :power_off_server
+    else
+      requeue_phase
+    end
   end
 
-  def poll_server_running
+  def power_off_server
+    update_and_notify_parent(:message => msg('stop server'))
+    source.power_down
+    signal :poll_server_off
+  end
+
+  def poll_server_off
+    if source.powered_off_now?
+      signal :power_on_server
+    else
+      requeue_phase
+    end
+  end
+
+  def power_on_server
+    source.power_up
+    signal :poll_server_on
+  end
+
+  def poll_server_on
     if source.powered_on_now?
       signal :done_provisioning
     else

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/physical_server/provisioning_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/physical_server/provisioning_spec.rb
@@ -40,19 +40,18 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::PhysicalServer do
     end
   end
 
-  describe '#reboot_using_pxe' do
+  describe '#next_boot_using_pxe' do
     context 'when boot order setup succeeds' do
       it 'server is restarted' do
         expect(system).to receive(:patch).and_return(double('RESPONSE', :status => 200, :data => {}))
-        expect(subject).to receive(:restart_now)
-        subject.reboot_using_pxe
+        subject.next_boot_using_pxe
       end
     end
 
     context 'when boot order setup fails' do
       it 'is provisioning aborted' do
         expect(system).to receive(:patch).and_return(double('RESPONSE', :status => 400, :data => {}))
-        expect { subject.reboot_using_pxe }.to raise_error(MiqException::MiqProvisionError)
+        expect { subject.next_boot_using_pxe }.to raise_error(MiqException::MiqProvisionError)
       end
     end
   end
@@ -66,6 +65,18 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::PhysicalServer do
     context 'when Off' do
       before { allow(system).to receive(:PowerState).and_return('Off') }
       it { expect(subject.powered_on_now?).to be_falsey }
+    end
+  end
+
+  describe '#powered_off_now?' do
+    context 'when On' do
+      before { allow(system).to receive(:PowerState).and_return('On') }
+      it { expect(subject.powered_off_now?).to be_falsey }
+    end
+
+    context 'when Off' do
+      before { allow(system).to receive(:PowerState).and_return('Off') }
+      it { expect(subject.powered_off_now?).to be_truthy }
     end
   end
 

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/provision/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/provision/state_machine_spec.rb
@@ -26,17 +26,73 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Provision do
     end
 
     context 'abort when missing customization template' do
-      let(:options) { { :customization_template_id => 'missing' } }
+      let(:options) { { :pxe_image_id => pxe_image.id, :customization_template_id => 'missing' } }
       it do
+        expect { subject.start_provisioning }.to raise_error(MiqException::MiqProvisionError)
+      end
+    end
+
+    context 'abort when server is in unexpected power state' do
+      let(:options) { { :pxe_image_id => pxe_image.id, :customization_template_id => template.id } }
+      it do
+        expect(server).to receive(:deploy_pxe_config).with(pxe_image, template)
+        expect(server).to receive(:next_boot_using_pxe)
+        expect(server).to receive(:power_state_now).and_return('something-unexpected')
         expect { subject.start_provisioning }.to raise_error(MiqException::MiqProvisionError)
       end
     end
 
     context 'when all steps succeed' do
       let(:options) { { :pxe_image_id => pxe_image.id, :customization_template_id => template.id } }
-      it do
+
+      it "properly handles server that is powering on" do
         expect(server).to receive(:deploy_pxe_config).with(pxe_image, template)
-        expect(server).to receive(:reboot_using_pxe)
+        expect(server).to receive(:next_boot_using_pxe)
+
+        expect(server).to receive(:power_state_now).and_return("poweringon")
+        expect(server).to receive(:powered_on_now?).and_return(true)
+        expect(server).to receive(:power_down)
+        expect(server).to receive(:powered_off_now?).and_return(true)
+        expect(server).to receive(:power_up)
+        expect(server).to receive(:powered_on_now?).and_return(true)
+
+        expect(subject).to receive(:done_provisioning)
+        subject.start_provisioning
+      end
+
+      it "properly handles server that is on" do
+        expect(server).to receive(:deploy_pxe_config).with(pxe_image, template)
+        expect(server).to receive(:next_boot_using_pxe)
+
+        expect(server).to receive(:power_state_now).and_return("on")
+        expect(server).to receive(:power_down)
+        expect(server).to receive(:powered_off_now?).and_return(true)
+        expect(server).to receive(:power_up)
+        expect(server).to receive(:powered_on_now?).and_return(true)
+
+        expect(subject).to receive(:done_provisioning)
+        subject.start_provisioning
+      end
+
+      it "properly handles server that is powering off" do
+        expect(server).to receive(:deploy_pxe_config).with(pxe_image, template)
+        expect(server).to receive(:next_boot_using_pxe)
+
+        expect(server).to receive(:power_state_now).and_return("poweringoff")
+        expect(server).to receive(:powered_off_now?).and_return(true)
+        expect(server).to receive(:power_up)
+        expect(server).to receive(:powered_on_now?).and_return(true)
+
+        expect(subject).to receive(:done_provisioning)
+        subject.start_provisioning
+      end
+
+      it "properly handles server that is off" do
+        expect(server).to receive(:deploy_pxe_config).with(pxe_image, template)
+        expect(server).to receive(:next_boot_using_pxe)
+
+        expect(server).to receive(:power_state_now).and_return("off")
+        expect(server).to receive(:power_up)
         expect(server).to receive(:powered_on_now?).and_return(true)
 
         expect(subject).to receive(:done_provisioning)
@@ -48,7 +104,13 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Provision do
       let(:options) { { :pxe_image_id => pxe_image.id, :customization_template_id => template.id } }
       it do
         expect(server).to receive(:deploy_pxe_config).with(pxe_image, template)
-        expect(server).to receive(:reboot_using_pxe)
+        expect(server).to receive(:next_boot_using_pxe)
+
+        expect(server).to receive(:power_state_now).and_return("poweringon")
+        expect(server).to receive(:powered_on_now?).and_return(false, true)
+        expect(server).to receive(:power_down)
+        expect(server).to receive(:powered_off_now?).and_return(false, true)
+        expect(server).to receive(:power_up)
         expect(server).to receive(:powered_on_now?).and_return(false, false, true)
 
         expect(subject).to receive(:done_provisioning)


### PR DESCRIPTION
Currently we configure server's PXE boot properties and then reboot it. Turns out, however, that server reboot operation is not always even supported. Therefore we now rather stop server and then spin it again. This way we don't rely on reboot operation support in favor of stop+start.

But beware it's not always trivial to shut server down: we had to handle four possible power states of the server or else the process would not succeed.

Depends on: https://github.com/ManageIQ/manageiq-providers-redfish/pull/74