### PR TITLE
Bump redfish_client version

### DIFF
--- a/manageiq-providers-redfish.gemspec
+++ b/manageiq-providers-redfish.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency "redfish_client", "~> 0.4.0"
+  s.add_runtime_dependency "redfish_client", "~> 0.5.1"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "redfish_tools", "~> 0.1"

--- a/spec/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager_spec.rb
@@ -1,6 +1,6 @@
 describe ManageIQ::Providers::Redfish::Inventory::Parser::PhysicalInfraManager do
   def new_resource(content)
-    RedfishClient::Resource.new(nil, :content => content)
+    RedfishClient::Resource.new(nil, :raw => content)
   end
 
   subject(:parser) { described_class.new }


### PR DESCRIPTION
A newer version of the Redfish client contains support for asynchronous responses that will come in handy when we start to poll long-running operations for termination.

@miq-bot assign @agrare 
@miq-bot add_reviewer @miha-plesko 