### PR TITLE
Checked power operations

### DIFF
--- a/app/models/manageiq/providers/redfish/physical_infra_manager/operations/power.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager/operations/power.rb
@@ -42,6 +42,16 @@ module ManageIQ::Providers::Redfish
       raise MiqException::Error, "Restarting BMC is not supported."
     end
 
+    # Select any supported method of powering the server down.
+    def power_down(server, _options)
+      trigger_first_valid_power_action(server, %w[ForceOff GracefulShutdown])
+    end
+
+    # Select any supported method of powering the server up.
+    def power_up(server, _options)
+      trigger_first_valid_power_action(server, %w[On ForceOn])
+    end
+
     private
 
     def trigger_first_valid_power_action(server, rtypes)

--- a/app/models/manageiq/providers/redfish/physical_infra_manager/physical_server.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager/physical_server.rb
@@ -9,5 +9,13 @@ module ManageIQ::Providers::Redfish
     def provider_object(connection)
       connection.find!(ems_ref)
     end
+
+    def power_down
+      change_state(:power_down)
+    end
+
+    def power_up
+      change_state(:power_up)
+    end
   end
 end

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/operations/power_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/operations/power_spec.rb
@@ -50,4 +50,16 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager do
         .to raise_error(MiqException::Error)
     end
   end
+
+  describe "#power_down", :vcr do
+    it "powers down the server with first suitable option" do
+      expect(ems.power_down(server, nil).status).to eq(200)
+    end
+  end
+
+  describe "#power_up", :vcr do
+    it "power up the server with first suitable option" do
+      expect(ems.power_up(server, nil).status).to eq(200)
+    end
+  end
 end

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_down/powers_down_the_server_with_first_suitable_option.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_down/powers_down_the_server_with_first_suitable_option.yml
@@ -1,0 +1,179 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
+      Date:
+      - Sun, 16 Jun 2019 07:35:11 GMT
+      Content-Length:
+      - '362'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
+        Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
+    http_version: 
+  recorded_at: Sun, 16 Jun 2019 07:35:11 GMT
+- request:
+    method: post
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
+    body:
+      encoding: UTF-8
+      string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: 'Created '
+    headers:
+      Content-Type:
+      - application/json
+      X-Auth-Token:
+      - 06dc8091-5520-40ab-b986-6a7c87769bea
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
+      Date:
+      - Sun, 16 Jun 2019 07:35:11 GMT
+      Content-Length:
+      - '253'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/06dc8091-5520-40ab-b986-6a7c87769bea","Id":"06dc8091-5520-40ab-b986-6a7c87769bea","Name":"06dc8091-5520-40ab-b986-6a7c87769bea","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+    http_version: 
+  recorded_at: Sun, 16 Jun 2019 07:35:11 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 06dc8091-5520-40ab-b986-6a7c87769bea
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
+      Date:
+      - Sun, 16 Jun 2019 07:35:11 GMT
+      Content-Length:
+      - '976'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Description":"G5
+        Computer System Node","Id":"System-1-1-1-1","IndicatorLED":"Off","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
+        Computer System","PowerState":"On","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
+    http_version: 
+  recorded_at: Sun, 16 Jun 2019 07:35:11 GMT
+- request:
+    method: post
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset
+    body:
+      encoding: UTF-8
+      string: '{"ResetType":"ForceOff"}'
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 06dc8091-5520-40ab-b986-6a7c87769bea
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
+      Date:
+      - Sun, 16 Jun 2019 07:35:11 GMT
+      Content-Length:
+      - '31'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error":{"message":"Success"}}'
+    http_version: 
+  recorded_at: Sun, 16 Jun 2019 07:35:11 GMT
+- request:
+    method: delete
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/06dc8091-5520-40ab-b986-6a7c87769bea
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 06dc8091-5520-40ab-b986-6a7c87769bea
+  response:
+    status:
+      code: 204
+      message: 'No Content '
+    headers:
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
+      Date:
+      - Sun, 16 Jun 2019 07:35:11 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Sun, 16 Jun 2019 07:35:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_up/power_up_the_server_with_first_suitable_option.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_up/power_up_the_server_with_first_suitable_option.yml
@@ -1,0 +1,179 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
+      Date:
+      - Sun, 16 Jun 2019 07:35:11 GMT
+      Content-Length:
+      - '362'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
+        Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
+    http_version: 
+  recorded_at: Sun, 16 Jun 2019 07:35:11 GMT
+- request:
+    method: post
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
+    body:
+      encoding: UTF-8
+      string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: 'Created '
+    headers:
+      Content-Type:
+      - application/json
+      X-Auth-Token:
+      - 6f7c8bd4-e2cd-4db4-9cad-212cfb114687
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
+      Date:
+      - Sun, 16 Jun 2019 07:35:11 GMT
+      Content-Length:
+      - '253'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/6f7c8bd4-e2cd-4db4-9cad-212cfb114687","Id":"6f7c8bd4-e2cd-4db4-9cad-212cfb114687","Name":"6f7c8bd4-e2cd-4db4-9cad-212cfb114687","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+    http_version: 
+  recorded_at: Sun, 16 Jun 2019 07:35:11 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 6f7c8bd4-e2cd-4db4-9cad-212cfb114687
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
+      Date:
+      - Sun, 16 Jun 2019 07:35:11 GMT
+      Content-Length:
+      - '977'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Description":"G5
+        Computer System Node","Id":"System-1-1-1-1","IndicatorLED":"Off","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
+        Computer System","PowerState":"Off","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
+    http_version: 
+  recorded_at: Sun, 16 Jun 2019 07:35:11 GMT
+- request:
+    method: post
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset
+    body:
+      encoding: UTF-8
+      string: '{"ResetType":"On"}'
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 6f7c8bd4-e2cd-4db4-9cad-212cfb114687
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
+      Date:
+      - Sun, 16 Jun 2019 07:35:11 GMT
+      Content-Length:
+      - '31'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error":{"message":"Success"}}'
+    http_version: 
+  recorded_at: Sun, 16 Jun 2019 07:35:11 GMT
+- request:
+    method: delete
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/6f7c8bd4-e2cd-4db4-9cad-212cfb114687
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - 6f7c8bd4-e2cd-4db4-9cad-212cfb114687
+  response:
+    status:
+      code: 204
+      message: 'No Content '
+    headers:
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
+      Date:
+      - Sun, 16 Jun 2019 07:35:11 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version: 
+  recorded_at: Sun, 16 Jun 2019 07:35:11 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Newly added functions in this commit try to power down (or power up) the computer by any means possible. By introducing two new methods, we made it possible to power down or power up the computer without having to query the Redfish service for supported reset types manually.

Depends on:

  * [x] #74 Refactor power actions

/cc @miha-plesko 