### PR TITLE
Make sure provider_object returns valid object

### DIFF
--- a/app/models/manageiq/providers/redfish/physical_infra_manager/physical_server.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager/physical_server.rb
@@ -7,7 +7,7 @@ module ManageIQ::Providers::Redfish
     end
 
     def provider_object(connection)
-      connection.find(ems_ref)
+      connection.find!(ems_ref)
     end
   end
 end

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/physical_server_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/physical_server_spec.rb
@@ -15,5 +15,11 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::PhysicalServer do
         expect(subject.ems_ref).to match(".+/#{system.Id}")
       end
     end
+
+    it "raises en exception if provider object is missing" do
+      subject.ems_ref = "/invalid"
+      expect { subject.with_provider_object { |_| nil } }
+        .to raise_error RedfishClient::Resource::NoResource
+    end
   end
 end

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager_PhysicalServer/_with_provider_object/raises_en_exception_if_provider_object_is_missing.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager_PhysicalServer/_with_provider_object/raises_en_exception_if_provider_object_is_missing.yml
@@ -1,0 +1,138 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
+      Date:
+      - Wed, 05 Jun 2019 11:31:11 GMT
+      Content-Length:
+      - '362'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
+        Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
+    http_version:
+  recorded_at: Wed, 05 Jun 2019 11:31:11 GMT
+- request:
+    method: post
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
+    body:
+      encoding: UTF-8
+      string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: 'Created '
+    headers:
+      Content-Type:
+      - application/json
+      X-Auth-Token:
+      - f994d5ca-d5af-4a9b-a459-f4ce487d3cae
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
+      Date:
+      - Wed, 05 Jun 2019 11:31:11 GMT
+      Content-Length:
+      - '253'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/f994d5ca-d5af-4a9b-a459-f4ce487d3cae","Id":"f994d5ca-d5af-4a9b-a459-f4ce487d3cae","Name":"f994d5ca-d5af-4a9b-a459-f4ce487d3cae","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+    http_version:
+  recorded_at: Wed, 05 Jun 2019 11:31:11 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/invalid
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - f994d5ca-d5af-4a9b-a459-f4ce487d3cae
+  response:
+    status:
+      code: 404
+      message: 'Not Found '
+    headers:
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
+      Date:
+      - Wed, 05 Jun 2019 11:31:11 GMT
+      Content-Length:
+      - '0'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version:
+  recorded_at: Wed, 05 Jun 2019 11:31:11 GMT
+- request:
+    method: delete
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/f994d5ca-d5af-4a9b-a459-f4ce487d3cae
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - f994d5ca-d5af-4a9b-a459-f4ce487d3cae
+  response:
+    status:
+      code: 204
+      message: 'No Content '
+    headers:
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
+      Date:
+      - Wed, 05 Jun 2019 11:31:11 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    http_version:
+  recorded_at: Wed, 05 Jun 2019 11:31:11 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
There is a non-zero chance of ManageIQ database and external Redfish system to be out-of-sync when the PhysicalServer#provider_object method is called. In this situation, the current implementation
returns the nil object, causing hard to debug problems down the line.

To give a sensible error message to the developers, we changed the provider_object method a bit. This method now raises an exception of the object cannot be retrieved from the external system.

@miq-bot assign @miha-plesko 