### PR TITLE
Refactor power actions

### DIFF
--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/operations/power_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/operations/power_spec.rb
@@ -1,48 +1,53 @@
 describe ManageIQ::Providers::Redfish::PhysicalInfraManager do
-  let(:server) { FactoryBot.create(:redfish_physical_server, :vcr) }
   subject(:ems) do
     FactoryBot.create(:ems_redfish_physical_infra, :vcr)
+  end
+  let(:server) do
+    FactoryBot.create(:redfish_physical_server, :vcr,
+                      :ext_management_system => ems)
   end
 
   describe "#power_on", :vcr do
     it "powers on the system" do
-      ems.power_on(server, nil)
+      expect { ems.power_on(server, nil) }.to raise_error(MiqException::Error)
     end
   end
 
   describe "#power_off", :vcr do
     it "powers off the system" do
-      ems.power_off(server, nil)
+      expect(ems.power_off(server, nil).status).to eq(200)
     end
   end
 
   describe "#power_off_now", :vcr do
     it "powers off the system immediately" do
-      ems.power_off_now(server, nil)
+      expect(ems.power_off_now(server, nil).status).to eq(200)
     end
   end
 
   describe "#restart", :vcr do
     it "restarts the system" do
-      ems.restart(server, nil)
+      expect(ems.restart(server, nil).status).to eq(200)
     end
   end
 
   describe "#restart_now", :vcr do
     it "restarts the system immediately" do
-      ems.restart_now(server, nil)
+      expect(ems.restart_now(server, nil).status).to eq(200)
     end
   end
 
   describe "#restart_to_sys_setup", :vcr do
     it "restarts to system setup" do
-      ems.restart_to_sys_setup(server, nil)
+      expect { ems.restart_to_sys_setup(server, nil) }
+        .to raise_error(MiqException::Error)
     end
   end
 
   describe "#restart_mgmt_controller", :vcr do
     it "restarts management controller" do
-      ems.restart_mgmt_controller(server, nil)
+      expect { ems.restart_mgmt_controller(server, nil) }
+        .to raise_error(MiqException::Error)
     end
   end
 end

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_off/powers_off_the_system.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_off/powers_off_the_system.yml
@@ -21,9 +21,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:56 GMT
+      - Thu, 06 Jun 2019 18:03:10 GMT
       Content-Length:
       - '362'
       Connection:
@@ -33,7 +33,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
         Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Thu, 06 Jun 2019 18:03:10 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
@@ -57,20 +57,20 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - 9f5b1717-6e4a-4a6f-95ac-7f07973ccfdd
+      - 15d5eda9-0551-4125-8575-96138c95cc17
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Thu, 06 Jun 2019 18:03:10 GMT
       Content-Length:
-      - '256'
+      - '253'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/9f5b1717-6e4a-4a6f-95ac-7f07973ccfdd","Id":"9f5b1717-6e4a-4a6f-95ac-7f07973ccfdd","Name":"9f5b1717-6e4a-4a6f-95ac-7f07973ccfdd","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/15d5eda9-0551-4125-8575-96138c95cc17","Id":"15d5eda9-0551-4125-8575-96138c95cc17","Name":"15d5eda9-0551-4125-8575-96138c95cc17","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Thu, 06 Jun 2019 18:03:10 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
@@ -85,7 +85,7 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9f5b1717-6e4a-4a6f-95ac-7f07973ccfdd
+      - 15d5eda9-0551-4125-8575-96138c95cc17
   response:
     status:
       code: 200
@@ -94,20 +94,20 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Thu, 06 Jun 2019 18:03:10 GMT
       Content-Length:
-      - '984'
+      - '1243'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Description":"G5
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Boot":{"BootOrder":["Hdd","Cd","Usb"],"BootSourceOverrideEnabled":"Disabled","BootSourceOverrideEnabled@Redfish.AllowableValues":["Continuous","Disabled","Once"],"BootSourceOverrideMode":"Legacy","BootSourceOverrideTarget":"Hdd","UefiTargetBootSourceOverride":null},"Description":"G5
         Computer System Node","Id":"System-1-1-1-1","IndicatorLED":"Off","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
-        Computer System","PowerState":"PoweringOn","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
+        Computer System","PowerState":"On","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Thu, 06 Jun 2019 18:03:10 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset
@@ -122,45 +122,32 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9f5b1717-6e4a-4a6f-95ac-7f07973ccfdd
+      - 15d5eda9-0551-4125-8575-96138c95cc17
       Content-Type:
       - application/json
   response:
     status:
-      code: 500
-      message: 'Internal Server Error '
+      code: 200
+      message: 'OK '
     headers:
       Content-Type:
-      - text/html; charset=ISO-8859-1
+      - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Thu, 06 Jun 2019 18:03:10 GMT
       Content-Length:
-      - '335'
+      - '31'
       Connection:
-      - close
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: |
-        <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
-        <HTML>
-          <HEAD><TITLE>Internal Server Error</TITLE></HEAD>
-          <BODY>
-            <H1>Internal Server Error</H1>
-            undefined method `key?' for nil:NilClass
-            <HR>
-            <ADDRESS>
-             WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g at
-             REDFISH_HOST:8889
-            </ADDRESS>
-          </BODY>
-        </HTML>
+      string: '{"error":{"message":"Success"}}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Thu, 06 Jun 2019 18:03:10 GMT
 - request:
     method: delete
-    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/9f5b1717-6e4a-4a6f-95ac-7f07973ccfdd
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/15d5eda9-0551-4125-8575-96138c95cc17
     body:
       encoding: US-ASCII
       string: ''
@@ -172,21 +159,21 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9f5b1717-6e4a-4a6f-95ac-7f07973ccfdd
+      - 15d5eda9-0551-4125-8575-96138c95cc17
   response:
     status:
       code: 204
       message: 'No Content '
     headers:
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Thu, 06 Jun 2019 18:03:10 GMT
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Thu, 06 Jun 2019 18:03:10 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_off_now/powers_off_the_system_immediately.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_off_now/powers_off_the_system_immediately.yml
@@ -21,9 +21,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:56 GMT
+      - Thu, 06 Jun 2019 18:03:43 GMT
       Content-Length:
       - '362'
       Connection:
@@ -33,7 +33,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
         Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:56 GMT
+  recorded_at: Thu, 06 Jun 2019 18:03:43 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
@@ -57,20 +57,20 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - 8fdef912-85db-4cbf-95c0-09c4610387fa
+      - dcea1096-be69-4fde-8e9d-ccfbf0d59f2a
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:56 GMT
+      - Thu, 06 Jun 2019 18:03:43 GMT
       Content-Length:
-      - '256'
+      - '253'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/8fdef912-85db-4cbf-95c0-09c4610387fa","Id":"8fdef912-85db-4cbf-95c0-09c4610387fa","Name":"8fdef912-85db-4cbf-95c0-09c4610387fa","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/dcea1096-be69-4fde-8e9d-ccfbf0d59f2a","Id":"dcea1096-be69-4fde-8e9d-ccfbf0d59f2a","Name":"dcea1096-be69-4fde-8e9d-ccfbf0d59f2a","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:56 GMT
+  recorded_at: Thu, 06 Jun 2019 18:03:43 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
@@ -85,7 +85,7 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 8fdef912-85db-4cbf-95c0-09c4610387fa
+      - dcea1096-be69-4fde-8e9d-ccfbf0d59f2a
   response:
     status:
       code: 200
@@ -94,20 +94,20 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:56 GMT
+      - Thu, 06 Jun 2019 18:03:43 GMT
       Content-Length:
-      - '984'
+      - '1243'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Description":"G5
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Boot":{"BootOrder":["Hdd","Cd","Usb"],"BootSourceOverrideEnabled":"Disabled","BootSourceOverrideEnabled@Redfish.AllowableValues":["Continuous","Disabled","Once"],"BootSourceOverrideMode":"Legacy","BootSourceOverrideTarget":"Hdd","UefiTargetBootSourceOverride":null},"Description":"G5
         Computer System Node","Id":"System-1-1-1-1","IndicatorLED":"Off","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
-        Computer System","PowerState":"PoweringOn","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
+        Computer System","PowerState":"On","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:56 GMT
+  recorded_at: Thu, 06 Jun 2019 18:03:43 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset
@@ -122,45 +122,32 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 8fdef912-85db-4cbf-95c0-09c4610387fa
+      - dcea1096-be69-4fde-8e9d-ccfbf0d59f2a
       Content-Type:
       - application/json
   response:
     status:
-      code: 500
-      message: 'Internal Server Error '
+      code: 200
+      message: 'OK '
     headers:
       Content-Type:
-      - text/html; charset=ISO-8859-1
+      - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:56 GMT
+      - Thu, 06 Jun 2019 18:03:43 GMT
       Content-Length:
-      - '335'
+      - '31'
       Connection:
-      - close
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: |
-        <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
-        <HTML>
-          <HEAD><TITLE>Internal Server Error</TITLE></HEAD>
-          <BODY>
-            <H1>Internal Server Error</H1>
-            undefined method `key?' for nil:NilClass
-            <HR>
-            <ADDRESS>
-             WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g at
-             REDFISH_HOST:8889
-            </ADDRESS>
-          </BODY>
-        </HTML>
+      string: '{"error":{"message":"Success"}}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:56 GMT
+  recorded_at: Thu, 06 Jun 2019 18:03:43 GMT
 - request:
     method: delete
-    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/8fdef912-85db-4cbf-95c0-09c4610387fa
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/dcea1096-be69-4fde-8e9d-ccfbf0d59f2a
     body:
       encoding: US-ASCII
       string: ''
@@ -172,21 +159,21 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 8fdef912-85db-4cbf-95c0-09c4610387fa
+      - dcea1096-be69-4fde-8e9d-ccfbf0d59f2a
   response:
     status:
       code: 204
       message: 'No Content '
     headers:
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:56 GMT
+      - Thu, 06 Jun 2019 18:03:43 GMT
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:56 GMT
+  recorded_at: Thu, 06 Jun 2019 18:03:43 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_on/powers_on_the_system.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_power_on/powers_on_the_system.yml
@@ -21,9 +21,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Thu, 06 Jun 2019 18:06:24 GMT
       Content-Length:
       - '362'
       Connection:
@@ -33,7 +33,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
         Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Thu, 06 Jun 2019 18:06:24 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
@@ -57,20 +57,20 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - 032d2c4e-a30f-430c-98ce-5da08d9dac55
+      - 9c82d6e9-425f-4059-bb41-a6ec0a7e73c5
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Thu, 06 Jun 2019 18:06:24 GMT
       Content-Length:
-      - '256'
+      - '253'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/032d2c4e-a30f-430c-98ce-5da08d9dac55","Id":"032d2c4e-a30f-430c-98ce-5da08d9dac55","Name":"032d2c4e-a30f-430c-98ce-5da08d9dac55","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/9c82d6e9-425f-4059-bb41-a6ec0a7e73c5","Id":"9c82d6e9-425f-4059-bb41-a6ec0a7e73c5","Name":"9c82d6e9-425f-4059-bb41-a6ec0a7e73c5","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Thu, 06 Jun 2019 18:06:24 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
@@ -85,7 +85,7 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 032d2c4e-a30f-430c-98ce-5da08d9dac55
+      - 9c82d6e9-425f-4059-bb41-a6ec0a7e73c5
   response:
     status:
       code: 200
@@ -94,20 +94,20 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Thu, 06 Jun 2019 18:06:24 GMT
       Content-Length:
-      - '984'
+      - '1243'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Description":"G5
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Boot":{"BootOrder":["Hdd","Cd","Usb"],"BootSourceOverrideEnabled":"Disabled","BootSourceOverrideEnabled@Redfish.AllowableValues":["Continuous","Disabled","Once"],"BootSourceOverrideMode":"Legacy","BootSourceOverrideTarget":"Hdd","UefiTargetBootSourceOverride":null},"Description":"G5
         Computer System Node","Id":"System-1-1-1-1","IndicatorLED":"Off","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
-        Computer System","PowerState":"PoweringOn","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
+        Computer System","PowerState":"On","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Thu, 06 Jun 2019 18:06:24 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset
@@ -122,45 +122,32 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 032d2c4e-a30f-430c-98ce-5da08d9dac55
+      - 9c82d6e9-425f-4059-bb41-a6ec0a7e73c5
       Content-Type:
       - application/json
   response:
     status:
-      code: 500
-      message: 'Internal Server Error '
+      code: 400
+      message: 'Bad Request '
     headers:
       Content-Type:
-      - text/html; charset=ISO-8859-1
+      - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Thu, 06 Jun 2019 18:06:24 GMT
       Content-Length:
-      - '335'
+      - '59'
       Connection:
-      - close
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: |
-        <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
-        <HTML>
-          <HEAD><TITLE>Internal Server Error</TITLE></HEAD>
-          <BODY>
-            <H1>Internal Server Error</H1>
-            undefined method `key?' for nil:NilClass
-            <HR>
-            <ADDRESS>
-             WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g at
-             REDFISH_HOST:8889
-            </ADDRESS>
-          </BODY>
-        </HTML>
+      string: '{"error":{"message":"Invalid reset type for curent state"}}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Thu, 06 Jun 2019 18:06:24 GMT
 - request:
     method: delete
-    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/032d2c4e-a30f-430c-98ce-5da08d9dac55
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/9c82d6e9-425f-4059-bb41-a6ec0a7e73c5
     body:
       encoding: US-ASCII
       string: ''
@@ -172,21 +159,21 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 032d2c4e-a30f-430c-98ce-5da08d9dac55
+      - 9c82d6e9-425f-4059-bb41-a6ec0a7e73c5
   response:
     status:
       code: 204
       message: 'No Content '
     headers:
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Thu, 06 Jun 2019 18:06:24 GMT
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Thu, 06 Jun 2019 18:06:25 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_restart/restarts_the_system.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_restart/restarts_the_system.yml
@@ -21,9 +21,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Thu, 06 Jun 2019 18:06:42 GMT
       Content-Length:
       - '362'
       Connection:
@@ -33,7 +33,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
         Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Thu, 06 Jun 2019 18:06:42 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
@@ -57,20 +57,20 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - 3f6dbce1-4b0e-4a2f-ab34-f4265b763ca0
+      - 653059e0-422a-406c-9f28-211ae0ea7149
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Thu, 06 Jun 2019 18:06:42 GMT
       Content-Length:
-      - '256'
+      - '253'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/3f6dbce1-4b0e-4a2f-ab34-f4265b763ca0","Id":"3f6dbce1-4b0e-4a2f-ab34-f4265b763ca0","Name":"3f6dbce1-4b0e-4a2f-ab34-f4265b763ca0","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/653059e0-422a-406c-9f28-211ae0ea7149","Id":"653059e0-422a-406c-9f28-211ae0ea7149","Name":"653059e0-422a-406c-9f28-211ae0ea7149","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Thu, 06 Jun 2019 18:06:42 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
@@ -85,7 +85,7 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 3f6dbce1-4b0e-4a2f-ab34-f4265b763ca0
+      - 653059e0-422a-406c-9f28-211ae0ea7149
   response:
     status:
       code: 200
@@ -94,20 +94,20 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Thu, 06 Jun 2019 18:06:42 GMT
       Content-Length:
-      - '984'
+      - '1243'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Description":"G5
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Boot":{"BootOrder":["Hdd","Cd","Usb"],"BootSourceOverrideEnabled":"Disabled","BootSourceOverrideEnabled@Redfish.AllowableValues":["Continuous","Disabled","Once"],"BootSourceOverrideMode":"Legacy","BootSourceOverrideTarget":"Hdd","UefiTargetBootSourceOverride":null},"Description":"G5
         Computer System Node","Id":"System-1-1-1-1","IndicatorLED":"Off","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
-        Computer System","PowerState":"PoweringOn","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
+        Computer System","PowerState":"On","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Thu, 06 Jun 2019 18:06:42 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset
@@ -122,45 +122,32 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 3f6dbce1-4b0e-4a2f-ab34-f4265b763ca0
+      - 653059e0-422a-406c-9f28-211ae0ea7149
       Content-Type:
       - application/json
   response:
     status:
-      code: 500
-      message: 'Internal Server Error '
+      code: 200
+      message: 'OK '
     headers:
       Content-Type:
-      - text/html; charset=ISO-8859-1
+      - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Thu, 06 Jun 2019 18:06:42 GMT
       Content-Length:
-      - '335'
+      - '31'
       Connection:
-      - close
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: |
-        <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
-        <HTML>
-          <HEAD><TITLE>Internal Server Error</TITLE></HEAD>
-          <BODY>
-            <H1>Internal Server Error</H1>
-            undefined method `key?' for nil:NilClass
-            <HR>
-            <ADDRESS>
-             WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g at
-             REDFISH_HOST:8889
-            </ADDRESS>
-          </BODY>
-        </HTML>
+      string: '{"error":{"message":"Success"}}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Thu, 06 Jun 2019 18:06:42 GMT
 - request:
     method: delete
-    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/3f6dbce1-4b0e-4a2f-ab34-f4265b763ca0
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/653059e0-422a-406c-9f28-211ae0ea7149
     body:
       encoding: US-ASCII
       string: ''
@@ -172,21 +159,21 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 3f6dbce1-4b0e-4a2f-ab34-f4265b763ca0
+      - 653059e0-422a-406c-9f28-211ae0ea7149
   response:
     status:
       code: 204
       message: 'No Content '
     headers:
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Thu, 06 Jun 2019 18:06:42 GMT
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Thu, 06 Jun 2019 18:06:42 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_restart_now/restarts_the_system_immediately.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager/_restart_now/restarts_the_system_immediately.yml
@@ -21,9 +21,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Thu, 06 Jun 2019 18:07:04 GMT
       Content-Length:
       - '362'
       Connection:
@@ -33,7 +33,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
         Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Thu, 06 Jun 2019 18:07:04 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
@@ -57,20 +57,20 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - 30263ba4-847c-4422-b4ab-5b7e2f15aa97
+      - 3142e0d7-7589-4833-be60-abdbd8af8b4e
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Thu, 06 Jun 2019 18:07:04 GMT
       Content-Length:
-      - '256'
+      - '253'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/30263ba4-847c-4422-b4ab-5b7e2f15aa97","Id":"30263ba4-847c-4422-b4ab-5b7e2f15aa97","Name":"30263ba4-847c-4422-b4ab-5b7e2f15aa97","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/3142e0d7-7589-4833-be60-abdbd8af8b4e","Id":"3142e0d7-7589-4833-be60-abdbd8af8b4e","Name":"3142e0d7-7589-4833-be60-abdbd8af8b4e","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Thu, 06 Jun 2019 18:07:05 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
@@ -85,7 +85,7 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 30263ba4-847c-4422-b4ab-5b7e2f15aa97
+      - 3142e0d7-7589-4833-be60-abdbd8af8b4e
   response:
     status:
       code: 200
@@ -94,20 +94,20 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Thu, 06 Jun 2019 18:07:05 GMT
       Content-Length:
-      - '984'
+      - '1243'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Description":"G5
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Boot":{"BootOrder":["Hdd","Cd","Usb"],"BootSourceOverrideEnabled":"Disabled","BootSourceOverrideEnabled@Redfish.AllowableValues":["Continuous","Disabled","Once"],"BootSourceOverrideMode":"Legacy","BootSourceOverrideTarget":"Hdd","UefiTargetBootSourceOverride":null},"Description":"G5
         Computer System Node","Id":"System-1-1-1-1","IndicatorLED":"Off","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
-        Computer System","PowerState":"PoweringOn","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
+        Computer System","PowerState":"On","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Thu, 06 Jun 2019 18:07:05 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset
@@ -122,45 +122,32 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 30263ba4-847c-4422-b4ab-5b7e2f15aa97
+      - 3142e0d7-7589-4833-be60-abdbd8af8b4e
       Content-Type:
       - application/json
   response:
     status:
-      code: 500
-      message: 'Internal Server Error '
+      code: 200
+      message: 'OK '
     headers:
       Content-Type:
-      - text/html; charset=ISO-8859-1
+      - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Thu, 06 Jun 2019 18:07:05 GMT
       Content-Length:
-      - '335'
+      - '31'
       Connection:
-      - close
+      - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: |
-        <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
-        <HTML>
-          <HEAD><TITLE>Internal Server Error</TITLE></HEAD>
-          <BODY>
-            <H1>Internal Server Error</H1>
-            undefined method `key?' for nil:NilClass
-            <HR>
-            <ADDRESS>
-             WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g at
-             REDFISH_HOST:8889
-            </ADDRESS>
-          </BODY>
-        </HTML>
+      string: '{"error":{"message":"Success"}}'
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Thu, 06 Jun 2019 18:07:05 GMT
 - request:
     method: delete
-    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/30263ba4-847c-4422-b4ab-5b7e2f15aa97
+    uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions/3142e0d7-7589-4833-be60-abdbd8af8b4e
     body:
       encoding: US-ASCII
       string: ''
@@ -172,21 +159,21 @@ http_interactions:
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 30263ba4-847c-4422-b4ab-5b7e2f15aa97
+      - 3142e0d7-7589-4833-be60-abdbd8af8b4e
   response:
     status:
       code: 204
       message: 'No Content '
     headers:
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.0.2g
+      - WEBrick/1.3.1 (Ruby/2.4.4/2018-03-28) OpenSSL/1.1.0i
       Date:
-      - Fri, 19 Apr 2019 08:04:57 GMT
+      - Thu, 06 Jun 2019 18:07:05 GMT
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: ''
     http_version: 
-  recorded_at: Fri, 19 Apr 2019 08:04:57 GMT
+  recorded_at: Thu, 06 Jun 2019 18:07:05 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
The previous implementation was ignoring the failure statuses of the power operations, which was not optimal if we put it nicely.

New implementation raises an error if the operation either failed or is not available at all on selected Redfish system.

@miq-bot assign @agrare 
/cc @miha-plesko 