### PR TITLE
Pick correct IDs on all three pages

### DIFF
--- a/app/javascript/components/redfish-server-provision-dialog.jsx
+++ b/app/javascript/components/redfish-server-provision-dialog.jsx
@@ -20,10 +20,10 @@ class RedfishServerProvisionDialog extends React.Component {
   }
 
   selectedPhysicalServers = () => {
-    if(ManageIQ.record.recordId){ // Single-record page
-      this.setState({physicalServerIds: [ManageIQ.record.recordId]});
-    } else if(ManageIQ.gridChecks.length > 0){ // Multi-record page
+    if(ManageIQ.gridChecks && ManageIQ.gridChecks.length > 0){ // Multi-record page
       this.setState({physicalServerIds: ManageIQ.gridChecks});
+    } else if(ManageIQ.record.recordId){ // Single-record page
+      this.setState({physicalServerIds: [ManageIQ.record.recordId]});
     } else{
       this.setState({physicalServerIds: [], error: __('Please select at lest one physical server to provision.')});
     }


### PR DESCRIPTION
There are three pages where physical server provisioning can be initiated from:

```
A) server details page
B) all servers list (can pick multi)
C) provider servers list (can pick multi)
```
We were assuming server ID is stored as 'recordId' on details page and when it's null we take 'gridChecks' which is populated at server list page. But we forgot to cover case (C) where 'recordId' contains id of a provider (so it's not null) hence we picked wrong ID.

With this commit we reverse the IF statement to properly handle (C)
as well.

Fixes https://github.com/ManageIQ/manageiq-providers-redfish/issues/79