### PR TITLE
Update Rails' secrets access in VCR tests

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -15,15 +15,15 @@ FactoryBot.define do
 
       hostname do
         # Keep in sync with filter_sensitive_data in spec/spec_helper.rb!
-        Rails.application.secrets.redfish.try(:[], "host") || "redfishhost"
+        Rails.application.secrets.redfish.try(:[], :host) || "redfishhost"
       end
 
       after(:create) do |ems|
         secrets = Rails.application.secrets.redfish
         ems.authentications << FactoryBot.create(
           :authentication,
-          :userid   => secrets.try(:[], "userid") || "REDFISH_USERID",
-          :password => secrets.try(:[], "password") || "REDFISH_PASSWORD"
+          :userid   => secrets.try(:[], :userid) || "REDFISH_USERID",
+          :password => secrets.try(:[], :password) || "REDFISH_PASSWORD"
         )
       end
     end


### PR DESCRIPTION
Up until version 5.1.x of Rails, we were able to use symbol or string to access secret contents. For example, let us assume that we placed the following content into the `config/secrets.yml` file:

    test:
      redfish:
        some: content

Using Rails 5.0.x, the next two lines return the same value:

    Rails.application.secrets.redfish["some"]
    Rails.application.secrets.redfish[:some]

But when using Rails 5.1.x, the first line is not retrieving the same value as the second one.

@miq-bot assign @miha-plesko 