### PR TITLE
Expand inventory

### DIFF
--- a/app/models/manageiq/providers/redfish/inventory/collector/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/inventory/collector/physical_infra_manager.rb
@@ -11,5 +11,9 @@ module ManageIQ::Providers::Redfish
     def physical_chassis
       rf_client.Chassis.Members.reject { |c| c.ChassisType == "Rack" }
     end
+
+    def firmware_inventory
+      rf_client.UpdateService.FirmwareInventory&.Members || []
+    end
   end
 end

--- a/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
@@ -7,6 +7,7 @@ module ManageIQ::Providers::Redfish
       physical_racks
       physical_chassis
       physical_chassis_details
+      firmwares
     end
 
     private
@@ -117,6 +118,23 @@ module ManageIQ::Providers::Redfish
               :uid_ems      => controller["@odata.id"]
             )
           end
+        end
+      end
+    end
+
+    def firmwares
+      collector.firmware_inventory.each do |firmware|
+        # RelatedItem is actually an array and is not a typo.
+        (firmware.RelatedItem || []).each do |item|
+          server = persister.physical_servers.lazy_find(item["@odata.id"])
+          computer = persister.physical_server_computer_systems.lazy_find(server)
+          hardware = persister.physical_server_hardwares.lazy_find(computer)
+          persister.physical_server_firmwares.build(
+            :resource => hardware,
+            :build    => firmware.SoftwareId,
+            :name     => firmware.Name,
+            :version  => firmware.Version
+          )
         end
       end
     end

--- a/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
@@ -106,6 +106,18 @@ module ManageIQ::Providers::Redfish
             :uid_ems      => net_adapter["@odata.id"]
           )
         end
+        (s.Storage&.Members || []).each do |storage|
+          (storage.StorageControllers || []).each do |controller|
+            persister.physical_server_storage_adapters.build(
+              :hardware     => hardware,
+              :device_name  => controller.Name,
+              :device_type  => "storage",
+              :manufacturer => controller.Manufacturer,
+              :model        => controller.Model,
+              :uid_ems      => controller["@odata.id"]
+            )
+          end
+        end
       end
     end
 

--- a/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
@@ -50,13 +50,20 @@ module ManageIQ::Providers::Redfish
           :description        => s.Description,
           :location           => format_location(location),
           :location_led_state => s.IndicatorLED,
+          :machine_type       => machine_type(s),
           :manufacturer       => s.Manufacturer,
           :model              => s.Model,
+          :product_name       => s.Name,
           :rack_name          => location.dig("Placement", "Rack"),
           :resource           => server,
+          :room               => location.dig("PostalAddress", "Room"),
           :serial_number      => s.SerialNumber,
         )
       end
+    end
+
+    def machine_type(server)
+      server.Processors.Members.first.InstructionSet
     end
 
     def get_server_location(server)

--- a/app/models/manageiq/providers/redfish/inventory/persister/definitions/physical_infra_collections.rb
+++ b/app/models/manageiq/providers/redfish/inventory/persister/definitions/physical_infra_collections.rb
@@ -8,6 +8,7 @@ module ManageIQ::Providers::Redfish::Inventory::Persister::Definitions::Physical
       physical_server_computer_systems
       physical_server_hardwares
       physical_server_network_devices
+      physical_server_storage_adapters
 
       physical_racks
       physical_chassis

--- a/app/models/manageiq/providers/redfish/inventory/persister/definitions/physical_infra_collections.rb
+++ b/app/models/manageiq/providers/redfish/inventory/persister/definitions/physical_infra_collections.rb
@@ -7,6 +7,7 @@ module ManageIQ::Providers::Redfish::Inventory::Persister::Definitions::Physical
       physical_server_details
       physical_server_computer_systems
       physical_server_hardwares
+      physical_server_network_devices
 
       physical_racks
       physical_chassis

--- a/app/models/manageiq/providers/redfish/inventory/persister/definitions/physical_infra_collections.rb
+++ b/app/models/manageiq/providers/redfish/inventory/persister/definitions/physical_infra_collections.rb
@@ -9,6 +9,7 @@ module ManageIQ::Providers::Redfish::Inventory::Persister::Definitions::Physical
       physical_server_hardwares
       physical_server_network_devices
       physical_server_storage_adapters
+      physical_server_firmwares
 
       physical_racks
       physical_chassis

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
@@ -31,6 +31,12 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
           :disk_capacity   => 6_017_150_230_528,
           :memory_mb       => 32_768,
         },
+        :nic          => {
+          :device_name  => "Intel X722 LOM (onboard)",
+          :manufacturer => "Intel",
+          :model        => "Contoso X",
+          :uid_ems      => "/redfish/v1/Chassis/Sled-1-1-1/NetworkAdapters/nic-1",
+        },
       },
       "/redfish/v1/Systems/System-1-1-1-2" => nil,
       "/redfish/v1/Systems/System-1-2-1-1" => {
@@ -54,6 +60,7 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
           :disk_capacity   => 412_316_860_416,
           :memory_mb       => 32_768,
         },
+        :nic          => {},
       },
     }
   end
@@ -173,6 +180,7 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
         assert_physical_servers
         assert_physical_server_details
         assert_hardwares
+        assert_nics
         assert_racks
         assert_physical_chassis
         assert_physical_chassis_details
@@ -222,6 +230,13 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
       system = ComputerSystem.find_by!(:managed_entity => server)
       hardware = Hardware.find_by!(:computer_system => system)
       check_attributes(hardware, attrs, :hardware)
+    end
+  end
+
+  def assert_nics
+    servers.each do |server_ems_ref, attrs|
+      server = PhysicalServer.find_by!(:ems_ref => server_ems_ref)
+      check_attributes(server.hardware.nics.first, attrs, :nic)
     end
   end
 

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
@@ -31,6 +31,11 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
           :disk_capacity   => 6_017_150_230_528,
           :memory_mb       => 32_768,
         },
+        :firmware     => {
+          :build   => "IVE1",
+          :name    => "Bios",
+          :version => "1.20",
+        },
         :nic          => {
           :device_name  => "Intel X722 LOM (onboard)",
           :manufacturer => "Intel",
@@ -65,6 +70,11 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
           :cpu_total_cores => 20,
           :disk_capacity   => 412_316_860_416,
           :memory_mb       => 32_768,
+        },
+        :firmware     => {
+          :build   => "MyGTH-76",
+          :name    => "UEFI",
+          :version => "2.50.4a",
         },
         :nic          => {},
         :storage      => {},
@@ -187,6 +197,7 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
         assert_physical_servers
         assert_physical_server_details
         assert_hardwares
+        assert_firmwares
         assert_nics
         assert_storage_adapters
         assert_racks
@@ -238,6 +249,13 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
       system = ComputerSystem.find_by!(:managed_entity => server)
       hardware = Hardware.find_by!(:computer_system => system)
       check_attributes(hardware, attrs, :hardware)
+    end
+  end
+
+  def assert_firmwares
+    servers.each do |server_ems_ref, attrs|
+      server = PhysicalServer.find_by!(:ems_ref => server_ems_ref)
+      check_attributes(server.hardware.firmwares.first, attrs, :firmware)
     end
   end
 

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
@@ -37,6 +37,12 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
           :model        => "Contoso X",
           :uid_ems      => "/redfish/v1/Chassis/Sled-1-1-1/NetworkAdapters/nic-1",
         },
+        :storage      => {
+          :device_name  => "RAID Storage Adapter",
+          :manufacturer => "Contoso",
+          :model        => "SAS3508+SAS35x36",
+          :uid_ems      => "/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1#/StorageControllers/0",
+        },
       },
       "/redfish/v1/Systems/System-1-1-1-2" => nil,
       "/redfish/v1/Systems/System-1-2-1-1" => {
@@ -61,6 +67,7 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
           :memory_mb       => 32_768,
         },
         :nic          => {},
+        :storage      => {},
       },
     }
   end
@@ -181,6 +188,7 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
         assert_physical_server_details
         assert_hardwares
         assert_nics
+        assert_storage_adapters
         assert_racks
         assert_physical_chassis
         assert_physical_chassis_details
@@ -237,6 +245,13 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
     servers.each do |server_ems_ref, attrs|
       server = PhysicalServer.find_by!(:ems_ref => server_ems_ref)
       check_attributes(server.hardware.nics.first, attrs, :nic)
+    end
+  end
+
+  def assert_storage_adapters
+    servers.each do |server_ems_ref, attrs|
+      server = PhysicalServer.find_by!(:ems_ref => server_ems_ref)
+      check_attributes(server.hardware.storage_adapters.first, attrs, :storage)
     end
   end
 

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
@@ -18,9 +18,12 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
           :description        => "G5 Computer System Node",
           :location           => "123, Adams Ave., Chesapeake, VA",
           :location_led_state => "Off",
+          :machine_type       => "x86-64",
           :manufacturer       => "Dell",
           :model              => "DSS9630M",
+          :product_name       => "G5 Computer System",
           :rack_name          => "Rack-1",
+          :room               => "Room B",
           :serial_number      => "CN701636AB0013",
         },
         :hardware     => {

--- a/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager_Refresher/refresh/will_perform_a_full_refresh.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_Redfish_PhysicalInfraManager_Refresher/refresh/will_perform_a_full_refresh.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
@@ -21,19 +21,19 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:07 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
-      - '362'
+      - '420'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
-        Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
+        Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:07 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
@@ -42,7 +42,7 @@ http_interactions:
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
@@ -57,20 +57,20 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:07 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '253'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/9065ac4e-16e1-42b5-a8f5-d46598770bda","Id":"9065ac4e-16e1-42b5-a8f5-d46598770bda","Name":"9065ac4e-16e1-42b5-a8f5-d46598770bda","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/acf6e61f-e611-4d7b-8136-d1014028031d","Id":"acf6e61f-e611-4d7b-8136-d1014028031d","Name":"acf6e61f-e611-4d7b-8136-d1014028031d","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:07 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems
@@ -79,13 +79,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -94,9 +94,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:07 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '260'
       Connection:
@@ -106,7 +106,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/Systems","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2"},{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1"}],"Members@odata.count":3,"Name":"Computer
         System Collection"}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:07 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
@@ -115,13 +115,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -130,20 +130,20 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:07 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
-      - '984'
+      - '1340'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Description":"G5
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Boot":{"BootOrder":["Hdd","Cd","Usb"],"BootSourceOverrideEnabled":"Disabled","BootSourceOverrideEnabled@Redfish.AllowableValues":["Continuous","Disabled","Once"],"BootSourceOverrideMode":"Legacy","BootSourceOverrideTarget":"Hdd","UefiTargetBootSourceOverride":null},"Description":"G5
         Computer System Node","Id":"System-1-1-1-1","IndicatorLED":"Off","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
-        Computer System","PowerState":"PoweringOn","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
+        Computer System","NetworkInterfaces":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/NetworkInterfaces"},"PowerState":"PoweringOn","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:07 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2
@@ -152,13 +152,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -167,9 +167,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:07 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '972'
       Connection:
@@ -180,7 +180,7 @@ http_interactions:
         Computer System Node","Id":"System-1-1-1-2","IndicatorLED":"On","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
         Computer System","PowerState":"Off","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Processors"},"SerialNumber":"23840jr9384j","Status":{"Health":"Warning","State":"Enabled"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:07 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1
@@ -189,13 +189,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -204,9 +204,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:07 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '1109'
       Connection:
@@ -216,7 +216,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulRestart","GracefulShutdown","PushPowerButton","Nmi"],"target":"/redfish/v1/Systems/System-1-2-1-1/Actions/ComputerSystem.Reset"}},"HostName":"hostname.example.com","Id":"System-1-2-1-1","IndicatorLED":"Blinking","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-2-1"}],"Chassis@odata.count":1},"Manufacturer":"Dell
         Inc.","MemorySummary":{"MemoryMirroring":"System","Status":{"Health":null,"HealthRollup":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"System","PartNumber":"033RF3X04","PowerState":"On","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":null,"HealthRollup":null,"State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors"},"SerialNumber":"945hjf0927mf","SimpleStorage":{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Storage/Controllers"},"Status":{"Health":"Critical","State":"Disabled"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:07 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Sled-1-1-1
@@ -225,13 +225,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -240,19 +240,19 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:07 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
-      - '530'
+      - '611'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: '{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1","ChassisType":"Sled","Description":"G5
-        Sled-Level Enclosure","Id":"Sled-1-1-1","IndicatorLED":"Blinking","Links":{"ComputerSystems":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2"}],"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Block-1-1"}},"Manufacturer":"Dell","Model":"DSS9630M","Name":"G5_Sled","PartNumber":"cnwo8hfn4","PowerState":"Off","SerialNumber":"h894hf5n926h","Status":{"Health":"Warning","State":"StandbyOffline"}}'
+        Sled-Level Enclosure","Id":"Sled-1-1-1","IndicatorLED":"Blinking","Links":{"ComputerSystems":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2"}],"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Block-1-1"}},"Manufacturer":"Dell","Model":"DSS9630M","Name":"G5_Sled","NetworkAdapters":{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1/NetworkAdapters"},"PartNumber":"cnwo8hfn4","PowerState":"Off","SerialNumber":"h894hf5n926h","Status":{"Health":"Warning","State":"StandbyOffline"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:07 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Sled-1-2-1
@@ -261,13 +261,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -276,19 +276,19 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:07 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
-      - '465'
+      - '414'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: '{"@odata.id":"/redfish/v1/Chassis/Sled-1-2-1","ChassisType":"Sled","Description":"G5
-        Sled-Level Enclosure","Id":"Sled-1-2-1","IndicatorLED":"Off","Links":{"ComputerSystems":[{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1"},{"@odata.id":"/redfish/v1/Systems/System-1-2-1-2"}],"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Block-1-2"}},"Manufacturer":"Dell","Model":"DSS9630M","Name":"G5_Sled","PowerState":"Off","Status":{"Health":"OK","State":"StandbyOffline"}}'
+        Sled-Level Enclosure","Id":"Sled-1-2-1","IndicatorLED":"Off","Links":{"ComputerSystems":[{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1"}],"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Block-1-2"}},"Manufacturer":"Dell","Model":"DSS9630M","Name":"G5_Sled","PowerState":"Off","Status":{"Health":"OK","State":"StandbyOffline"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:07 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Block-1-1
@@ -297,13 +297,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -312,9 +312,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:07 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '526'
       Connection:
@@ -325,7 +325,7 @@ http_interactions:
         Block Chassis","Id":"Block-1-1","IndicatorLED":"On","Links":{"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Rack-1"},"Contains":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"},{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-2"}]},"Location":{"Placement":{"Rack":"Rack-1"}},"Manufacturer":"Dell","Model":"G5
         Block","Name":"G5_Block","PartNumber":"9845ujtf0347","PowerState":"On","SerialNumber":"11","Status":{"Health":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:07 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Rack-1
@@ -334,13 +334,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -349,56 +349,19 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:07 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
-      - '621'
+      - '637'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Chassis/Rack-1","Actions":{"#Chassis.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown"],"target":"/redfish/v1/Chassis/Rack-1/Actions/Chassis.Reset"}},"ChassisType":"Rack","Id":"Rack-1","Links":{"Contains":[{"@odata.id":"/redfish/v1/Chassis/Block-1-1"},{"@odata.id":"/redfish/v1/Chassis/Block-1-2"}]},"Location":{"PostalAddress":{"City":"Chesapeake","Country":"VA","HouseNumber":"123","Street":"Adams
-        Ave."}},"Manufacturer":"Dell","Model":"DSS9000","Name":"G5_Rack","PowerState":"On","SerialNumber":"1","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
+      string: '{"@odata.id":"/redfish/v1/Chassis/Rack-1","Actions":{"#Chassis.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown"],"target":"/redfish/v1/Chassis/Rack-1/Actions/Chassis.Reset"}},"ChassisType":"Rack","Id":"Rack-1","Links":{"Contains":[{"@odata.id":"/redfish/v1/Chassis/Block-1-1"},{"@odata.id":"/redfish/v1/Chassis/Block-1-2"}]},"Location":{"PostalAddress":{"City":"Chesapeake","Country":"VA","HouseNumber":"123","Room":"Room
+        B","Street":"Adams Ave."}},"Manufacturer":"Dell","Model":"DSS9000","Name":"G5_Rack","PowerState":"On","SerialNumber":"1","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:07 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Block-1-2
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:07 GMT
-      Content-Length:
-      - '458'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Chassis/Block-1-2","ChassisType":"Enclosure","Description":"G5
-        Block Chassis","Id":"Block-1-2","Links":{"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Rack-1"},"Contains":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-2-1"}]},"Location":{"Placement":{"Rack":"Rack-1"}},"Manufacturer":"Dell","Model":"G5
-        Block","Name":"G5_Block","PartNumber":"93j4fo3hn4f","PowerState":"On","SerialNumber":"12","Status":{"Health":"OK","State":"Enabled"}}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:07 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Processors
@@ -407,13 +370,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -422,9 +385,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:07 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '226'
       Connection:
@@ -433,7 +396,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors/","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors/1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors/2"}],"Members@odata.count":2}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:07 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Processors/1
@@ -442,13 +405,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -457,9 +420,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:07 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '626'
       Connection:
@@ -472,7 +435,7 @@ http_interactions:
         2.60GHz","Name":"Processor 1","ProcessorArchitecture":"x86","ProcessorId":{"EffectiveFamily":"0x06","EffectiveModel":"0x55","IdentificationRegisters":"0x00050654bfebfbff","MicrocodeInfo":null,"Step":"0x04","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU
         1","Status":{"Health":"OK","State":"Enabled"},"TotalCores":12,"TotalThreads":24}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:07 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Processors/2
@@ -481,13 +444,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -496,9 +459,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:07 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '626'
       Connection:
@@ -511,301 +474,7 @@ http_interactions:
         2.60GHz","Name":"Processor 2","ProcessorArchitecture":"x86","ProcessorId":{"EffectiveFamily":"0x06","EffectiveModel":"0x55","IdentificationRegisters":"0x00050654bfebfbff","MicrocodeInfo":null,"Step":"0x04","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU
         2","Status":{"Health":"OK","State":"Enabled"},"TotalCores":12,"TotalThreads":24}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:07 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:07 GMT
-      Content-Length:
-      - '294'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/","Description":"A
-        Collection of Storage resource instances.","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8"}],"Members@odata.count":2}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:07 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:07 GMT
-      Content-Length:
-      - '550'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/","Description":"This
-        resource is used to represent a storage for a Redfish implementation.","Drives":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.0"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.2"}],"Drives@odata.count":3,"Id":"RAID_Slot1","Name":"RAID
-        Storage","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:07 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:07 GMT
-      Content-Length:
-      - '477'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/","Description":"This
-        resource is used to represent a storage for a Redfish implementation.","Drives":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1"}],"Drives@odata.count":2,"Id":"M.2_Slot8","Name":"M.2
-        Storage","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:08 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:08 GMT
-      Content-Length:
-      - '597'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.0","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
-        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.0","Identifiers":[{"DurableName":"9847693487","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"984576947398476589","Status":{"Health":"OK","State":"Enabled"}}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:08 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:08 GMT
-      Content-Length:
-      - '591'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.1","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
-        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.1","Identifiers":[{"DurableName":"9345098734","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"938754938039","Status":{"Health":"OK","State":"Enabled"}}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:08 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.2
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:08 GMT
-      Content-Length:
-      - '599'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.2","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
-        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.2","Identifiers":[{"DurableName":"9854376923746987","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"09834579274032","Status":{"Health":"OK","State":"Enabled"}}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:08 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:08 GMT
-      Content-Length:
-      - '580'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0","CapacityBytes":128000000000,"Description":"This
-        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Drive.M.2_Bay0","Identifiers":[{"DurableName":"1234567890","DurableNameFormat":"UUID"}],"Manufacturer":"LEN","MediaType":"SSD","Model":"LITEON
-        CV3-8D128","Name":"128GB M.2 SATA SSD","PartNumber":"SSD0L20505","Protocol":"SATA","Revision":"T87RA34
-        ","RotationSpeedRPM":0,"SerialNumber":"83465192783","Status":{"Health":"OK","State":"Enabled"}}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:08 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:08 GMT
-      Content-Length:
-      - '584'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1","CapacityBytes":128000000000,"Description":"This
-        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Drive.M.2_Bay1","Identifiers":[{"DurableName":"1234567891","DurableNameFormat":"UUID"}],"Manufacturer":"LEN","MediaType":"SSD","Model":"LITEON
-        CV3-8D128","Name":"128GB M.2 SATA SSD","PartNumber":"SSD0L20505","Protocol":"SATA","Revision":"T87RA34
-        ","RotationSpeedRPM":0,"SerialNumber":"934759369847658","Status":{"Health":"OK","State":"Enabled"}}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:08 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Processors
@@ -814,13 +483,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -829,9 +498,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:08 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '226'
       Connection:
@@ -840,7 +509,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Processors/","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Processors/1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Processors/2"}],"Members@odata.count":2}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:08 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Processors/1
@@ -849,13 +518,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -864,9 +533,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:08 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '639'
       Connection:
@@ -879,7 +548,7 @@ http_interactions:
         2.60GHz","Name":"Processor 1","ProcessorArchitecture":"x86","ProcessorId":{"EffectiveFamily":"0x06","EffectiveModel":"0x55","IdentificationRegisters":"0x00050654bfebfbff","MicrocodeInfo":null,"Step":"0x04","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU
         1","Status":{"Health":"OK","State":"Enabled"},"TotalCores":12,"TotalThreads":24}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:08 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Processors/2
@@ -888,13 +557,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -903,9 +572,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:08 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '639'
       Connection:
@@ -918,22 +587,22 @@ http_interactions:
         2.60GHz","Name":"Processor 2","ProcessorArchitecture":"x86","ProcessorId":{"EffectiveFamily":"0x06","EffectiveModel":"0x55","IdentificationRegisters":"0x00050654bfebfbff","MicrocodeInfo":null,"Step":"0x04","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU
         2","Status":{"Health":"OK","State":"Enabled"},"TotalCores":12,"TotalThreads":24}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:08 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage
+    uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Block-1-2
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -942,9 +611,525 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:08 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '458'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Chassis/Block-1-2","ChassisType":"Enclosure","Description":"G5
+        Block Chassis","Id":"Block-1-2","Links":{"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Rack-1"},"Contains":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-2-1"}]},"Location":{"Placement":{"Rack":"Rack-1"}},"Manufacturer":"Dell","Model":"G5
+        Block","Name":"G5_Block","PartNumber":"93j4fo3hn4f","PowerState":"On","SerialNumber":"12","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1/Processors
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - acf6e61f-e611-4d7b-8136-d1014028031d
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '259'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors","Description":"Collection
+        of Processors for this System","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors/CPU.Socket.1"}],"Members@odata.count":1,"Name":"ProcessorsCollection"}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1/Processors/CPU.Socket.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - acf6e61f-e611-4d7b-8136-d1014028031d
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '562'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors/CPU.Socket.1","Description":"Represents
+        the properties of a Processor attached to this System","Id":"CPU.Socket.1","InstructionSet":[{"Member":"x86-64"}],"Manufacturer":"Intel","MaxSpeedMHz":4000,"Model":"","Name":"CPU
+        1","ProcessorArchitecture":[{"Member":"x86"}],"ProcessorId":{"EffectiveFamily":"6","EffectiveModel":"85","IdentificationRegisters":"0x00050652","MicrocodeInfo":null,"Step":"2","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU.Socket.1","TotalCores":20,"TotalThreads":40}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - acf6e61f-e611-4d7b-8136-d1014028031d
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '294'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/","Description":"A
+        Collection of Storage resource instances.","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8"}],"Members@odata.count":2}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - acf6e61f-e611-4d7b-8136-d1014028031d
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '814'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/","Description":"This
+        resource is used to represent a storage for a Redfish implementation.","Drives":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.0"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.2"}],"Drives@odata.count":3,"Id":"RAID_Slot1","Name":"RAID
+        Storage","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"},"StorageControllers":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1#/StorageControllers/0","FirmwareVersion":"50.3.0-1075","Manufacturer":"Contoso","Model":"SAS3508+SAS35x36","Name":"RAID
+        Storage Adapter"}],"StorageControllers@odata.count":1}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - acf6e61f-e611-4d7b-8136-d1014028031d
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '477'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/","Description":"This
+        resource is used to represent a storage for a Redfish implementation.","Drives":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1"}],"Drives@odata.count":2,"Id":"M.2_Slot8","Name":"M.2
+        Storage","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - acf6e61f-e611-4d7b-8136-d1014028031d
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '597'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.0","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.0","Identifiers":[{"DurableName":"9847693487","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"984576947398476589","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - acf6e61f-e611-4d7b-8136-d1014028031d
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '591'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.1","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.1","Identifiers":[{"DurableName":"9345098734","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"938754938039","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - acf6e61f-e611-4d7b-8136-d1014028031d
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '599'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.2","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.2","Identifiers":[{"DurableName":"9854376923746987","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"09834579274032","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - acf6e61f-e611-4d7b-8136-d1014028031d
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '580'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0","CapacityBytes":128000000000,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Drive.M.2_Bay0","Identifiers":[{"DurableName":"1234567890","DurableNameFormat":"UUID"}],"Manufacturer":"LEN","MediaType":"SSD","Model":"LITEON
+        CV3-8D128","Name":"128GB M.2 SATA SSD","PartNumber":"SSD0L20505","Protocol":"SATA","Revision":"T87RA34
+        ","RotationSpeedRPM":0,"SerialNumber":"83465192783","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - acf6e61f-e611-4d7b-8136-d1014028031d
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '584'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1","CapacityBytes":128000000000,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Drive.M.2_Bay1","Identifiers":[{"DurableName":"1234567891","DurableNameFormat":"UUID"}],"Manufacturer":"LEN","MediaType":"SSD","Model":"LITEON
+        CV3-8D128","Name":"128GB M.2 SATA SSD","PartNumber":"SSD0L20505","Protocol":"SATA","Revision":"T87RA34
+        ","RotationSpeedRPM":0,"SerialNumber":"934759369847658","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/NetworkInterfaces
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - acf6e61f-e611-4d7b-8136-d1014028031d
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '268'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/1/NetworkInterfaces/","Description":"A
+        Collection of NetworkInterface resource instances.","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/NetworkInterfaces/1"}],"Members@odata.count":1,"Name":"NetworkInterfaceCollection"}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/NetworkInterfaces/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - acf6e61f-e611-4d7b-8136-d1014028031d
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '388'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/1/NetworkInterfaces/1","Description":"A
+        NetworkInterface contains references linking NetworkAdapter, NetworkPort,
+        and NetworkDeviceFunction resources and represents the functionality available
+        to the containing system.","Id":"1","Links":{"NetworkAdapter":{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1/NetworkAdapters/nic-1"}},"Name":"Network
+        Interface 1"}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Sled-1-1-1/NetworkAdapters/nic-1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - acf6e61f-e611-4d7b-8136-d1014028031d
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '158'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1/NetworkAdapters/nic-1","Id":"nic-1","Manufacturer":"Intel","Model":"Contoso
+        X","Name":"Intel X722 LOM (onboard)"}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - acf6e61f-e611-4d7b-8136-d1014028031d
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '294'
       Connection:
@@ -954,7 +1139,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/","Description":"A
         Collection of Storage resource instances.","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8"}],"Members@odata.count":2}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:08 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1
@@ -963,13 +1148,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -978,9 +1163,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:08 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '550'
       Connection:
@@ -991,7 +1176,7 @@ http_interactions:
         resource is used to represent a storage for a Redfish implementation.","Drives":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.0"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.2"}],"Drives@odata.count":3,"Id":"RAID_Slot1","Name":"RAID
         Storage","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:08 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8
@@ -1000,13 +1185,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -1015,9 +1200,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:08 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '477'
       Connection:
@@ -1028,7 +1213,7 @@ http_interactions:
         resource is used to represent a storage for a Redfish implementation.","Drives":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1"}],"Drives@odata.count":2,"Id":"M.2_Slot8","Name":"M.2
         Storage","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:08 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.0
@@ -1037,13 +1222,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -1052,9 +1237,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:08 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '595'
       Connection:
@@ -1064,7 +1249,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.0","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
         resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.0","Identifiers":[{"DurableName":"098453t0h432","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"9823jf3149jdf1","Status":{"Health":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:08 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.1
@@ -1073,13 +1258,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -1088,9 +1273,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:08 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '595'
       Connection:
@@ -1100,7 +1285,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.1","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
         resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.1","Identifiers":[{"DurableName":"98483j590j249","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"983j90f8j1349","Status":{"Health":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:08 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.2
@@ -1109,13 +1294,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -1124,9 +1309,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:08 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '600'
       Connection:
@@ -1136,7 +1321,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.2","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
         resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.2","Identifiers":[{"DurableName":"90845j09fj0345","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"9084ut9fm2o3987jn","Status":{"Health":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:08 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0
@@ -1145,13 +1330,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -1160,9 +1345,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:08 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '581'
       Connection:
@@ -1174,7 +1359,7 @@ http_interactions:
         CV3-8D128","Name":"128GB M.2 SATA SSD","PartNumber":"SSD0L20505","Protocol":"SATA","Revision":"T87RA34
         ","RotationSpeedRPM":0,"SerialNumber":"9504868r903j","Status":{"Health":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:08 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1
@@ -1183,13 +1368,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -1198,9 +1383,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:08 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '584'
       Connection:
@@ -1212,80 +1397,7 @@ http_interactions:
         CV3-8D128","Name":"128GB M.2 SATA SSD","PartNumber":"SSD0L20505","Protocol":"SATA","Revision":"T87RA34
         ","RotationSpeedRPM":0,"SerialNumber":"7rh8o32h47","Status":{"Health":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:08 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1/Processors
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:08 GMT
-      Content-Length:
-      - '259'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors","Description":"Collection
-        of Processors for this System","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors/CPU.Socket.1"}],"Members@odata.count":1,"Name":"ProcessorsCollection"}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:08 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1/Processors/CPU.Socket.1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:08 GMT
-      Content-Length:
-      - '562'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors/CPU.Socket.1","Description":"Represents
-        the properties of a Processor attached to this System","Id":"CPU.Socket.1","InstructionSet":[{"Member":"x86-64"}],"Manufacturer":"Intel","MaxSpeedMHz":4000,"Model":"","Name":"CPU
-        1","ProcessorArchitecture":[{"Member":"x86"}],"ProcessorId":{"EffectiveFamily":"6","EffectiveModel":"85","IdentificationRegisters":"0x00050652","MicrocodeInfo":null,"Step":"2","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU.Socket.1","TotalCores":20,"TotalThreads":40}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:08 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1/Storage/Controllers
@@ -1294,13 +1406,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -1309,9 +1421,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:08 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '288'
       Connection:
@@ -1322,7 +1434,7 @@ http_interactions:
         of Controllers for this system","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Storage/Controllers/AHCI.Embedded.1-1"}],"Members@odata.count":1,"Name":"Simple
         Storage Collection"}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:08 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1/Storage/Controllers/AHCI.Embedded.1-1
@@ -1331,13 +1443,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -1346,9 +1458,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:08 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '453'
       Connection:
@@ -1360,7 +1472,7 @@ http_interactions:
         storage device 2","Status":{"Health":"OK","State":"Enabled"},"CapacityBytes":137438953472}],"Devices@odata.count":2,"Id":"AHCI.Embedded.1-1","Name":"Lewisburg
         SSATA Controller [AHCI mode]"}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:09 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Chassis
@@ -1369,13 +1481,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -1384,9 +1496,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:09 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '436'
       Connection:
@@ -1395,7 +1507,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"@odata.id":"/redfish/v1/Chassis","Members":[{"@odata.id":"/redfish/v1/Chassis/Rack-1"},{"@odata.id":"/redfish/v1/Chassis/Block-1-1"},{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"},{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-2"},{"@odata.id":"/redfish/v1/Chassis/Block-1-2"},{"@odata.id":"/redfish/v1/Chassis/Sled-1-2-1"},{"@odata.id":"/redfish/v1/Chassis/Rack-2"},{"@odata.id":"/redfish/v1/Chassis/Block-2-1"}],"Members@odata.count":8}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:09 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Sled-1-1-2
@@ -1404,13 +1516,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -1419,19 +1531,19 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:09 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
-      - '414'
+      - '343'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: '{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-2","ChassisType":"Sled","Description":"G5
-        Sled-Level Enclosure","Id":"Sled-1-1-2","IndicatorLED":"Off","Links":{"ComputerSystems":[{"@odata.id":"/redfish/v1/Systems/System-1-1-2-1"}],"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Block-1-1"}},"Manufacturer":"Dell","Model":"DSS9630M","Name":"G5_Sled","PowerState":"Off","Status":{"Health":"OK","State":"StandbyOffline"}}'
+        Sled-Level Enclosure","Id":"Sled-1-1-2","IndicatorLED":"Off","Links":{"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Block-1-1"}},"Manufacturer":"Dell","Model":"DSS9630M","Name":"G5_Sled","PowerState":"Off","Status":{"Health":"OK","State":"StandbyOffline"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:09 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Rack-2
@@ -1440,13 +1552,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -1455,9 +1567,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:09 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '575'
       Connection:
@@ -1467,7 +1579,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/Chassis/Rack-2","Actions":{"#Chassis.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown"],"target":"/redfish/v1/Chassis/Rack-2/Actions/Chassis.Reset"}},"ChassisType":"Rack","Id":"Rack-2","Links":{"Contains":[{"@odata.id":"/redfish/v1/Chassis/Block-2-1"}]},"Location":{"PostalAddress":{"City":"Chesapeake","Country":"VA","HouseNumber":"123","Street":"Adams
         Ave."}},"Manufacturer":"Dell","Model":"DSS9000","Name":"G5_Rack","PowerState":"On","SerialNumber":"2","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:09 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Block-2-1
@@ -1476,13 +1588,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - 9065ac4e-16e1-42b5-a8f5-d46598770bda
+      - acf6e61f-e611-4d7b-8136-d1014028031d
   response:
     status:
       code: 200
@@ -1491,9 +1603,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:09 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '371'
       Connection:
@@ -1504,7 +1616,186 @@ http_interactions:
         Block Chassis","Id":"Block-2-1","Links":{"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Rack-2"}},"Location":{"Placement":{"Rack":"Rack-2"}},"Manufacturer":"Dell","Model":"G5
         Block","Name":"G5_Block","PowerState":"On","SerialNumber":"21","Status":{"Health":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:09 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/UpdateService
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - acf6e61f-e611-4d7b-8136-d1014028031d
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '166'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/UpdateService","FirmwareInventory":{"@odata.id":"/redfish/v1/UpdateService/FirmwareInventory"},"Id":"UpdateService","Name":"Update
+        Service"}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/UpdateService/FirmwareInventory
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - acf6e61f-e611-4d7b-8136-d1014028031d
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '332'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/UpdateService/FirmwareInventory/","Members":[{"@odata.id":"/redfish/v1/UpdateService/FirmwareInventory/Bios"},{"@odata.id":"/redfish/v1/UpdateService/FirmwareInventory/NIC-drvs"},{"@odata.id":"/redfish/v1/UpdateService/FirmwareInventory/UEFI"}],"Members@odata.count":3,"Name":"SoftwareInventoryCollection"}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/UpdateService/FirmwareInventory/Bios
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - acf6e61f-e611-4d7b-8136-d1014028031d
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '323'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/UpdateService/FirmwareInventory/Bios","Description":"The
+        information on Bios firmware.","Id":"Bios","Name":"Bios","RelatedItem":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2"}],"RelatedItem@odata.count":2,"SoftwareId":"IVE1","Version":"1.20"}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/UpdateService/FirmwareInventory/NIC-drvs
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - acf6e61f-e611-4d7b-8136-d1014028031d
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '195'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/UpdateService/FirmwareInventory/NIC-drvs","Description":"The
+        information on NIC drivers.","Id":"NIC-drvs","Name":"NIC-drvs","SoftwareId":"NIC-45-HJK","Version":"5.32.5"}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/UpdateService/FirmwareInventory/UEFI
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - acf6e61f-e611-4d7b-8136-d1014028031d
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '270'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/UpdateService/FirmwareInventory/UEFI","Description":"The
+        information on UEFI.","Id":"UEFI","Name":"UEFI","RelatedItem":[{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1"}],"RelatedItem@odata.count":1,"SoftwareId":"MyGTH-76","Version":"2.50.4a"}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1
@@ -1513,7 +1804,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
@@ -1526,19 +1817,19 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:09 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
-      - '362'
+      - '420'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: '{"@odata.id":"/redfish/v1/","Chassis":{"@odata.id":"/redfish/v1/Chassis"},"EventService":{"@odata.id":"/redfish/v1/EventService"},"Id":"RootService","Links":{"Sessions":{"@odata.id":"/redfish/v1/SessionService/Sessions"}},"Name":"RackManager
-        Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"}}'
+        Root Service","SessionService":{"@odata.id":"/redfish/v1/SessionService"},"Systems":{"@odata.id":"/redfish/v1/Systems"},"UpdateService":{"@odata.id":"/redfish/v1/UpdateService"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:09 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: post
     uri: https://REDFISH_HOST:8889/redfish/v1/SessionService/Sessions
@@ -1547,7 +1838,7 @@ http_interactions:
       string: '{"UserName":"REDFISH_USERID","Password":"REDFISH_PASSWORD"}'
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
@@ -1562,20 +1853,20 @@ http_interactions:
       Content-Type:
       - application/json
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:09 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '253'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/bf841a19-fa6b-424d-84cb-32800d857370","Id":"bf841a19-fa6b-424d-84cb-32800d857370","Name":"bf841a19-fa6b-424d-84cb-32800d857370","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
+      string: '{"@odata.id":"/redfish/v1/SessionService/Sessions/cefd9360-62e8-46a2-850f-fb81ae472c2e","Id":"cefd9360-62e8-46a2-850f-fb81ae472c2e","Name":"cefd9360-62e8-46a2-850f-fb81ae472c2e","@odata.type":"#Session.v1_1_0.Session","UserName":"REDFISH_USERID","Password":null}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:09 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems
@@ -1584,13 +1875,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -1599,9 +1890,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:09 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '260'
       Connection:
@@ -1611,7 +1902,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/Systems","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2"},{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1"}],"Members@odata.count":3,"Name":"Computer
         System Collection"}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:09 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1
@@ -1620,13 +1911,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -1635,20 +1926,20 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:09 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
-      - '984'
+      - '1340'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Description":"G5
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"],"target":"/redfish/v1/Systems/System-1-1-1-1/Actions/ComputerSystem.Reset"}},"Boot":{"BootOrder":["Hdd","Cd","Usb"],"BootSourceOverrideEnabled":"Disabled","BootSourceOverrideEnabled@Redfish.AllowableValues":["Continuous","Disabled","Once"],"BootSourceOverrideMode":"Legacy","BootSourceOverrideTarget":"Hdd","UefiTargetBootSourceOverride":null},"Description":"G5
         Computer System Node","Id":"System-1-1-1-1","IndicatorLED":"Off","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
-        Computer System","PowerState":"PoweringOn","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
+        Computer System","NetworkInterfaces":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/NetworkInterfaces"},"PowerState":"PoweringOn","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors"},"SerialNumber":"CN701636AB0013","Status":{"Health":"OK","State":"StandbyOffline"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:09 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2
@@ -1657,13 +1948,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -1672,9 +1963,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:09 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '972'
       Connection:
@@ -1685,7 +1976,7 @@ http_interactions:
         Computer System Node","Id":"System-1-1-1-2","IndicatorLED":"On","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"}]},"Manufacturer":"Dell","MemorySummary":{"Status":{"Health":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"G5
         Computer System","PowerState":"Off","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":"OK","State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Processors"},"SerialNumber":"23840jr9384j","Status":{"Health":"Warning","State":"Enabled"},"Storage":{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:09 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1
@@ -1694,13 +1985,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -1709,9 +2000,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:09 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '1109'
       Connection:
@@ -1721,7 +2012,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1","Actions":{"#ComputerSystem.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulRestart","GracefulShutdown","PushPowerButton","Nmi"],"target":"/redfish/v1/Systems/System-1-2-1-1/Actions/ComputerSystem.Reset"}},"HostName":"hostname.example.com","Id":"System-1-2-1-1","IndicatorLED":"Blinking","Links":{"Chassis":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-2-1"}],"Chassis@odata.count":1},"Manufacturer":"Dell
         Inc.","MemorySummary":{"MemoryMirroring":"System","Status":{"Health":null,"HealthRollup":null,"State":"Enabled"},"TotalSystemMemoryGiB":32},"Model":"DSS9630M","Name":"System","PartNumber":"033RF3X04","PowerState":"On","ProcessorSummary":{"Count":2,"Model":"","Status":{"Health":null,"HealthRollup":null,"State":"Enabled"}},"Processors":{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors"},"SerialNumber":"945hjf0927mf","SimpleStorage":{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Storage/Controllers"},"Status":{"Health":"Critical","State":"Disabled"},"SystemType":"Physical","UUID":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:09 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Sled-1-1-1
@@ -1730,13 +2021,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -1745,19 +2036,19 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:09 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
-      - '530'
+      - '611'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: '{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1","ChassisType":"Sled","Description":"G5
-        Sled-Level Enclosure","Id":"Sled-1-1-1","IndicatorLED":"Blinking","Links":{"ComputerSystems":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2"}],"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Block-1-1"}},"Manufacturer":"Dell","Model":"DSS9630M","Name":"G5_Sled","PartNumber":"cnwo8hfn4","PowerState":"Off","SerialNumber":"h894hf5n926h","Status":{"Health":"Warning","State":"StandbyOffline"}}'
+        Sled-Level Enclosure","Id":"Sled-1-1-1","IndicatorLED":"Blinking","Links":{"ComputerSystems":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2"}],"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Block-1-1"}},"Manufacturer":"Dell","Model":"DSS9630M","Name":"G5_Sled","NetworkAdapters":{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1/NetworkAdapters"},"PartNumber":"cnwo8hfn4","PowerState":"Off","SerialNumber":"h894hf5n926h","Status":{"Health":"Warning","State":"StandbyOffline"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:09 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Sled-1-2-1
@@ -1766,13 +2057,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -1781,19 +2072,19 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:09 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
-      - '465'
+      - '414'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: '{"@odata.id":"/redfish/v1/Chassis/Sled-1-2-1","ChassisType":"Sled","Description":"G5
-        Sled-Level Enclosure","Id":"Sled-1-2-1","IndicatorLED":"Off","Links":{"ComputerSystems":[{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1"},{"@odata.id":"/redfish/v1/Systems/System-1-2-1-2"}],"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Block-1-2"}},"Manufacturer":"Dell","Model":"DSS9630M","Name":"G5_Sled","PowerState":"Off","Status":{"Health":"OK","State":"StandbyOffline"}}'
+        Sled-Level Enclosure","Id":"Sled-1-2-1","IndicatorLED":"Off","Links":{"ComputerSystems":[{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1"}],"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Block-1-2"}},"Manufacturer":"Dell","Model":"DSS9630M","Name":"G5_Sled","PowerState":"Off","Status":{"Health":"OK","State":"StandbyOffline"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:09 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Block-1-1
@@ -1802,13 +2093,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -1817,9 +2108,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:09 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '526'
       Connection:
@@ -1830,7 +2121,7 @@ http_interactions:
         Block Chassis","Id":"Block-1-1","IndicatorLED":"On","Links":{"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Rack-1"},"Contains":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"},{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-2"}]},"Location":{"Placement":{"Rack":"Rack-1"}},"Manufacturer":"Dell","Model":"G5
         Block","Name":"G5_Block","PartNumber":"9845ujtf0347","PowerState":"On","SerialNumber":"11","Status":{"Health":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:09 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Rack-1
@@ -1839,13 +2130,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -1854,56 +2145,19 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:09 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
-      - '621'
+      - '637'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Chassis/Rack-1","Actions":{"#Chassis.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown"],"target":"/redfish/v1/Chassis/Rack-1/Actions/Chassis.Reset"}},"ChassisType":"Rack","Id":"Rack-1","Links":{"Contains":[{"@odata.id":"/redfish/v1/Chassis/Block-1-1"},{"@odata.id":"/redfish/v1/Chassis/Block-1-2"}]},"Location":{"PostalAddress":{"City":"Chesapeake","Country":"VA","HouseNumber":"123","Street":"Adams
-        Ave."}},"Manufacturer":"Dell","Model":"DSS9000","Name":"G5_Rack","PowerState":"On","SerialNumber":"1","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
+      string: '{"@odata.id":"/redfish/v1/Chassis/Rack-1","Actions":{"#Chassis.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown"],"target":"/redfish/v1/Chassis/Rack-1/Actions/Chassis.Reset"}},"ChassisType":"Rack","Id":"Rack-1","Links":{"Contains":[{"@odata.id":"/redfish/v1/Chassis/Block-1-1"},{"@odata.id":"/redfish/v1/Chassis/Block-1-2"}]},"Location":{"PostalAddress":{"City":"Chesapeake","Country":"VA","HouseNumber":"123","Room":"Room
+        B","Street":"Adams Ave."}},"Manufacturer":"Dell","Model":"DSS9000","Name":"G5_Rack","PowerState":"On","SerialNumber":"1","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:09 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Block-1-2
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:09 GMT
-      Content-Length:
-      - '458'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Chassis/Block-1-2","ChassisType":"Enclosure","Description":"G5
-        Block Chassis","Id":"Block-1-2","Links":{"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Rack-1"},"Contains":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-2-1"}]},"Location":{"Placement":{"Rack":"Rack-1"}},"Manufacturer":"Dell","Model":"G5
-        Block","Name":"G5_Block","PartNumber":"93j4fo3hn4f","PowerState":"On","SerialNumber":"12","Status":{"Health":"OK","State":"Enabled"}}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:09 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Processors
@@ -1912,13 +2166,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -1927,9 +2181,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:09 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '226'
       Connection:
@@ -1938,7 +2192,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors/","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors/1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Processors/2"}],"Members@odata.count":2}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:09 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Processors/1
@@ -1947,13 +2201,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -1962,9 +2216,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:09 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '626'
       Connection:
@@ -1977,7 +2231,7 @@ http_interactions:
         2.60GHz","Name":"Processor 1","ProcessorArchitecture":"x86","ProcessorId":{"EffectiveFamily":"0x06","EffectiveModel":"0x55","IdentificationRegisters":"0x00050654bfebfbff","MicrocodeInfo":null,"Step":"0x04","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU
         1","Status":{"Health":"OK","State":"Enabled"},"TotalCores":12,"TotalThreads":24}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:09 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Processors/2
@@ -1986,13 +2240,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -2001,9 +2255,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:09 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '626'
       Connection:
@@ -2016,301 +2270,7 @@ http_interactions:
         2.60GHz","Name":"Processor 2","ProcessorArchitecture":"x86","ProcessorId":{"EffectiveFamily":"0x06","EffectiveModel":"0x55","IdentificationRegisters":"0x00050654bfebfbff","MicrocodeInfo":null,"Step":"0x04","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU
         2","Status":{"Health":"OK","State":"Enabled"},"TotalCores":12,"TotalThreads":24}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:09 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:09 GMT
-      Content-Length:
-      - '294'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/","Description":"A
-        Collection of Storage resource instances.","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8"}],"Members@odata.count":2}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:10 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:10 GMT
-      Content-Length:
-      - '550'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/","Description":"This
-        resource is used to represent a storage for a Redfish implementation.","Drives":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.0"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.2"}],"Drives@odata.count":3,"Id":"RAID_Slot1","Name":"RAID
-        Storage","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:10 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:10 GMT
-      Content-Length:
-      - '477'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/","Description":"This
-        resource is used to represent a storage for a Redfish implementation.","Drives":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1"}],"Drives@odata.count":2,"Id":"M.2_Slot8","Name":"M.2
-        Storage","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:10 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:10 GMT
-      Content-Length:
-      - '597'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.0","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
-        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.0","Identifiers":[{"DurableName":"9847693487","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"984576947398476589","Status":{"Health":"OK","State":"Enabled"}}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:10 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:10 GMT
-      Content-Length:
-      - '591'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.1","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
-        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.1","Identifiers":[{"DurableName":"9345098734","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"938754938039","Status":{"Health":"OK","State":"Enabled"}}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:10 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.2
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:10 GMT
-      Content-Length:
-      - '599'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.2","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
-        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.2","Identifiers":[{"DurableName":"9854376923746987","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"09834579274032","Status":{"Health":"OK","State":"Enabled"}}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:10 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:10 GMT
-      Content-Length:
-      - '580'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0","CapacityBytes":128000000000,"Description":"This
-        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Drive.M.2_Bay0","Identifiers":[{"DurableName":"1234567890","DurableNameFormat":"UUID"}],"Manufacturer":"LEN","MediaType":"SSD","Model":"LITEON
-        CV3-8D128","Name":"128GB M.2 SATA SSD","PartNumber":"SSD0L20505","Protocol":"SATA","Revision":"T87RA34
-        ","RotationSpeedRPM":0,"SerialNumber":"83465192783","Status":{"Health":"OK","State":"Enabled"}}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:10 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:10 GMT
-      Content-Length:
-      - '584'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1","CapacityBytes":128000000000,"Description":"This
-        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Drive.M.2_Bay1","Identifiers":[{"DurableName":"1234567891","DurableNameFormat":"UUID"}],"Manufacturer":"LEN","MediaType":"SSD","Model":"LITEON
-        CV3-8D128","Name":"128GB M.2 SATA SSD","PartNumber":"SSD0L20505","Protocol":"SATA","Revision":"T87RA34
-        ","RotationSpeedRPM":0,"SerialNumber":"934759369847658","Status":{"Health":"OK","State":"Enabled"}}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:10 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Processors
@@ -2319,13 +2279,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -2334,9 +2294,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:10 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '226'
       Connection:
@@ -2345,7 +2305,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Processors/","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Processors/1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Processors/2"}],"Members@odata.count":2}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:10 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Processors/1
@@ -2354,13 +2314,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -2369,9 +2329,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:10 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '639'
       Connection:
@@ -2384,7 +2344,7 @@ http_interactions:
         2.60GHz","Name":"Processor 1","ProcessorArchitecture":"x86","ProcessorId":{"EffectiveFamily":"0x06","EffectiveModel":"0x55","IdentificationRegisters":"0x00050654bfebfbff","MicrocodeInfo":null,"Step":"0x04","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU
         1","Status":{"Health":"OK","State":"Enabled"},"TotalCores":12,"TotalThreads":24}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:10 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Processors/2
@@ -2393,13 +2353,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -2408,9 +2368,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:10 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '639'
       Connection:
@@ -2423,22 +2383,22 @@ http_interactions:
         2.60GHz","Name":"Processor 2","ProcessorArchitecture":"x86","ProcessorId":{"EffectiveFamily":"0x06","EffectiveModel":"0x55","IdentificationRegisters":"0x00050654bfebfbff","MicrocodeInfo":null,"Step":"0x04","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU
         2","Status":{"Health":"OK","State":"Enabled"},"TotalCores":12,"TotalThreads":24}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:10 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage
+    uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Block-1-2
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -2447,9 +2407,525 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:10 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '458'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Chassis/Block-1-2","ChassisType":"Enclosure","Description":"G5
+        Block Chassis","Id":"Block-1-2","Links":{"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Rack-1"},"Contains":[{"@odata.id":"/redfish/v1/Chassis/Sled-1-2-1"}]},"Location":{"Placement":{"Rack":"Rack-1"}},"Manufacturer":"Dell","Model":"G5
+        Block","Name":"G5_Block","PartNumber":"93j4fo3hn4f","PowerState":"On","SerialNumber":"12","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1/Processors
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '259'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors","Description":"Collection
+        of Processors for this System","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors/CPU.Socket.1"}],"Members@odata.count":1,"Name":"ProcessorsCollection"}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1/Processors/CPU.Socket.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '562'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors/CPU.Socket.1","Description":"Represents
+        the properties of a Processor attached to this System","Id":"CPU.Socket.1","InstructionSet":[{"Member":"x86-64"}],"Manufacturer":"Intel","MaxSpeedMHz":4000,"Model":"","Name":"CPU
+        1","ProcessorArchitecture":[{"Member":"x86"}],"ProcessorId":{"EffectiveFamily":"6","EffectiveModel":"85","IdentificationRegisters":"0x00050652","MicrocodeInfo":null,"Step":"2","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU.Socket.1","TotalCores":20,"TotalThreads":40}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '294'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/","Description":"A
+        Collection of Storage resource instances.","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8"}],"Members@odata.count":2}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '814'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/","Description":"This
+        resource is used to represent a storage for a Redfish implementation.","Drives":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.0"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.2"}],"Drives@odata.count":3,"Id":"RAID_Slot1","Name":"RAID
+        Storage","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"},"StorageControllers":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1#/StorageControllers/0","FirmwareVersion":"50.3.0-1075","Manufacturer":"Contoso","Model":"SAS3508+SAS35x36","Name":"RAID
+        Storage Adapter"}],"StorageControllers@odata.count":1}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '477'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/","Description":"This
+        resource is used to represent a storage for a Redfish implementation.","Drives":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1"}],"Drives@odata.count":2,"Id":"M.2_Slot8","Name":"M.2
+        Storage","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '597'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.0","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.0","Identifiers":[{"DurableName":"9847693487","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"984576947398476589","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '591'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.1","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.1","Identifiers":[{"DurableName":"9345098734","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"938754938039","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '599'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/RAID_Slot1/Drives/Disk.2","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.2","Identifiers":[{"DurableName":"9854376923746987","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"09834579274032","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '580'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0","CapacityBytes":128000000000,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Drive.M.2_Bay0","Identifiers":[{"DurableName":"1234567890","DurableNameFormat":"UUID"}],"Manufacturer":"LEN","MediaType":"SSD","Model":"LITEON
+        CV3-8D128","Name":"128GB M.2 SATA SSD","PartNumber":"SSD0L20505","Protocol":"SATA","Revision":"T87RA34
+        ","RotationSpeedRPM":0,"SerialNumber":"83465192783","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '584'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1","CapacityBytes":128000000000,"Description":"This
+        resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Drive.M.2_Bay1","Identifiers":[{"DurableName":"1234567891","DurableNameFormat":"UUID"}],"Manufacturer":"LEN","MediaType":"SSD","Model":"LITEON
+        CV3-8D128","Name":"128GB M.2 SATA SSD","PartNumber":"SSD0L20505","Protocol":"SATA","Revision":"T87RA34
+        ","RotationSpeedRPM":0,"SerialNumber":"934759369847658","Status":{"Health":"OK","State":"Enabled"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/NetworkInterfaces
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '268'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/1/NetworkInterfaces/","Description":"A
+        Collection of NetworkInterface resource instances.","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1/NetworkInterfaces/1"}],"Members@odata.count":1,"Name":"NetworkInterfaceCollection"}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-1/NetworkInterfaces/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '388'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Systems/1/NetworkInterfaces/1","Description":"A
+        NetworkInterface contains references linking NetworkAdapter, NetworkPort,
+        and NetworkDeviceFunction resources and represents the functionality available
+        to the containing system.","Id":"1","Links":{"NetworkAdapter":{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1/NetworkAdapters/nic-1"}},"Name":"Network
+        Interface 1"}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Sled-1-1-1/NetworkAdapters/nic-1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
+      Content-Length:
+      - '158'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1/NetworkAdapters/nic-1","Id":"nic-1","Manufacturer":"Intel","Model":"Contoso
+        X","Name":"Intel X722 LOM (onboard)"}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '294'
       Connection:
@@ -2459,7 +2935,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/","Description":"A
         Collection of Storage resource instances.","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8"}],"Members@odata.count":2}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:10 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1
@@ -2468,13 +2944,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -2483,9 +2959,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:10 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '550'
       Connection:
@@ -2496,7 +2972,7 @@ http_interactions:
         resource is used to represent a storage for a Redfish implementation.","Drives":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.0"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.2"}],"Drives@odata.count":3,"Id":"RAID_Slot1","Name":"RAID
         Storage","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:10 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8
@@ -2505,13 +2981,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -2520,9 +2996,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:10 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '477'
       Connection:
@@ -2533,7 +3009,7 @@ http_interactions:
         resource is used to represent a storage for a Redfish implementation.","Drives":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1"}],"Drives@odata.count":2,"Id":"M.2_Slot8","Name":"M.2
         Storage","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:10 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.0
@@ -2542,13 +3018,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -2557,9 +3033,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:10 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '595'
       Connection:
@@ -2569,7 +3045,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.0","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
         resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.0","Identifiers":[{"DurableName":"098453t0h432","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"9823jf3149jdf1","Status":{"Health":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:10 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.1
@@ -2578,13 +3054,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -2593,9 +3069,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:10 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '595'
       Connection:
@@ -2605,7 +3081,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.1","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
         resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.1","Identifiers":[{"DurableName":"98483j590j249","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"983j90f8j1349","Status":{"Health":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:10 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.2
@@ -2614,13 +3090,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -2629,9 +3105,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:10 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '600'
       Connection:
@@ -2641,7 +3117,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2/Storage/RAID_Slot1/Drives/Disk.2","BlockSizeBytes":512,"CapableSpeedGbs":6,"CapacityBytes":1920383410176,"Description":"This
         resource is used to represent a drive for a Redfish implementation.","FailurePredicted":false,"Id":"Disk.2","Identifiers":[{"DurableName":"90845j09fj0345","DurableNameFormat":"UUID"}],"Manufacturer":"ATA","MediaType":null,"Model":"","Name":"MTFDDAK1T9TCB-1AR1ZA","PartNumber":"D7A09328","Protocol":"SATA","Revision":"MD44","RotationSpeedRPM":65535,"SerialNumber":"9084ut9fm2o3987jn","Status":{"Health":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:10 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/Drives/Drive.M.2_Bay0
@@ -2650,13 +3126,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -2665,9 +3141,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:10 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '581'
       Connection:
@@ -2679,7 +3155,7 @@ http_interactions:
         CV3-8D128","Name":"128GB M.2 SATA SSD","PartNumber":"SSD0L20505","Protocol":"SATA","Revision":"T87RA34
         ","RotationSpeedRPM":0,"SerialNumber":"9504868r903j","Status":{"Health":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:10 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-1-1-2/Storage/M.2_Slot8/Drives/Drive.M.2_Bay1
@@ -2688,13 +3164,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -2703,9 +3179,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:10 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '584'
       Connection:
@@ -2717,80 +3193,7 @@ http_interactions:
         CV3-8D128","Name":"128GB M.2 SATA SSD","PartNumber":"SSD0L20505","Protocol":"SATA","Revision":"T87RA34
         ","RotationSpeedRPM":0,"SerialNumber":"7rh8o32h47","Status":{"Health":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:10 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1/Processors
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:10 GMT
-      Content-Length:
-      - '259'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors","Description":"Collection
-        of Processors for this System","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors/CPU.Socket.1"}],"Members@odata.count":1,"Name":"ProcessorsCollection"}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:10 GMT
-- request:
-    method: get
-    uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1/Processors/CPU.Socket.1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - excon/0.62.0
-      Accept:
-      - application/json
-      Odata-Version:
-      - '4.0'
-      X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
-  response:
-    status:
-      code: 200
-      message: 'OK '
-    headers:
-      Content-Type:
-      - application/json
-      Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
-      Date:
-      - Mon, 24 Sep 2018 20:54:10 GMT
-      Content-Length:
-      - '562'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: ASCII-8BIT
-      string: '{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Processors/CPU.Socket.1","Description":"Represents
-        the properties of a Processor attached to this System","Id":"CPU.Socket.1","InstructionSet":[{"Member":"x86-64"}],"Manufacturer":"Intel","MaxSpeedMHz":4000,"Model":"","Name":"CPU
-        1","ProcessorArchitecture":[{"Member":"x86"}],"ProcessorId":{"EffectiveFamily":"6","EffectiveModel":"85","IdentificationRegisters":"0x00050652","MicrocodeInfo":null,"Step":"2","VendorId":"GenuineIntel"},"ProcessorType":"CPU","Socket":"CPU.Socket.1","TotalCores":20,"TotalThreads":40}'
-    http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:11 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1/Storage/Controllers
@@ -2799,13 +3202,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -2814,9 +3217,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:11 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '288'
       Connection:
@@ -2827,7 +3230,7 @@ http_interactions:
         of Controllers for this system","Members":[{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1/Storage/Controllers/AHCI.Embedded.1-1"}],"Members@odata.count":1,"Name":"Simple
         Storage Collection"}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:11 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Systems/System-1-2-1-1/Storage/Controllers/AHCI.Embedded.1-1
@@ -2836,13 +3239,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -2851,9 +3254,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:11 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '453'
       Connection:
@@ -2865,7 +3268,7 @@ http_interactions:
         storage device 2","Status":{"Health":"OK","State":"Enabled"},"CapacityBytes":137438953472}],"Devices@odata.count":2,"Id":"AHCI.Embedded.1-1","Name":"Lewisburg
         SSATA Controller [AHCI mode]"}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:11 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Chassis
@@ -2874,13 +3277,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -2889,9 +3292,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:11 GMT
+      - Mon, 08 Jul 2019 21:02:55 GMT
       Content-Length:
       - '436'
       Connection:
@@ -2900,7 +3303,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"@odata.id":"/redfish/v1/Chassis","Members":[{"@odata.id":"/redfish/v1/Chassis/Rack-1"},{"@odata.id":"/redfish/v1/Chassis/Block-1-1"},{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-1"},{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-2"},{"@odata.id":"/redfish/v1/Chassis/Block-1-2"},{"@odata.id":"/redfish/v1/Chassis/Sled-1-2-1"},{"@odata.id":"/redfish/v1/Chassis/Rack-2"},{"@odata.id":"/redfish/v1/Chassis/Block-2-1"}],"Members@odata.count":8}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:11 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:55 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Sled-1-1-2
@@ -2909,13 +3312,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -2924,19 +3327,19 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:11 GMT
+      - Mon, 08 Jul 2019 21:02:56 GMT
       Content-Length:
-      - '414'
+      - '343'
       Connection:
       - Keep-Alive
     body:
       encoding: ASCII-8BIT
       string: '{"@odata.id":"/redfish/v1/Chassis/Sled-1-1-2","ChassisType":"Sled","Description":"G5
-        Sled-Level Enclosure","Id":"Sled-1-1-2","IndicatorLED":"Off","Links":{"ComputerSystems":[{"@odata.id":"/redfish/v1/Systems/System-1-1-2-1"}],"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Block-1-1"}},"Manufacturer":"Dell","Model":"DSS9630M","Name":"G5_Sled","PowerState":"Off","Status":{"Health":"OK","State":"StandbyOffline"}}'
+        Sled-Level Enclosure","Id":"Sled-1-1-2","IndicatorLED":"Off","Links":{"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Block-1-1"}},"Manufacturer":"Dell","Model":"DSS9630M","Name":"G5_Sled","PowerState":"Off","Status":{"Health":"OK","State":"StandbyOffline"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:11 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:56 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Rack-2
@@ -2945,13 +3348,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -2960,9 +3363,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:11 GMT
+      - Mon, 08 Jul 2019 21:02:56 GMT
       Content-Length:
       - '575'
       Connection:
@@ -2972,7 +3375,7 @@ http_interactions:
       string: '{"@odata.id":"/redfish/v1/Chassis/Rack-2","Actions":{"#Chassis.Reset":{"ResetType@Redfish.AllowableValues":["On","ForceOff","GracefulShutdown"],"target":"/redfish/v1/Chassis/Rack-2/Actions/Chassis.Reset"}},"ChassisType":"Rack","Id":"Rack-2","Links":{"Contains":[{"@odata.id":"/redfish/v1/Chassis/Block-2-1"}]},"Location":{"PostalAddress":{"City":"Chesapeake","Country":"VA","HouseNumber":"123","Street":"Adams
         Ave."}},"Manufacturer":"Dell","Model":"DSS9000","Name":"G5_Rack","PowerState":"On","SerialNumber":"2","Status":{"Health":"OK","HealthRollup":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:11 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:56 GMT
 - request:
     method: get
     uri: https://REDFISH_HOST:8889/redfish/v1/Chassis/Block-2-1
@@ -2981,13 +3384,13 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - excon/0.62.0
+      - excon/0.64.0
       Accept:
       - application/json
       Odata-Version:
       - '4.0'
       X-Auth-Token:
-      - bf841a19-fa6b-424d-84cb-32800d857370
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
   response:
     status:
       code: 200
@@ -2996,9 +3399,9 @@ http_interactions:
       Content-Type:
       - application/json
       Server:
-      - WEBrick/1.3.1 (Ruby/2.4.3/2017-12-14) OpenSSL/1.1.0g
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
       Date:
-      - Mon, 24 Sep 2018 20:54:11 GMT
+      - Mon, 08 Jul 2019 21:02:56 GMT
       Content-Length:
       - '371'
       Connection:
@@ -3009,5 +3412,184 @@ http_interactions:
         Block Chassis","Id":"Block-2-1","Links":{"ContainedBy":{"@odata.id":"/redfish/v1/Chassis/Rack-2"}},"Location":{"Placement":{"Rack":"Rack-2"}},"Manufacturer":"Dell","Model":"G5
         Block","Name":"G5_Block","PowerState":"On","SerialNumber":"21","Status":{"Health":"OK","State":"Enabled"}}'
     http_version: 
-  recorded_at: Mon, 24 Sep 2018 20:54:11 GMT
+  recorded_at: Mon, 08 Jul 2019 21:02:56 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/UpdateService
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:56 GMT
+      Content-Length:
+      - '166'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/UpdateService","FirmwareInventory":{"@odata.id":"/redfish/v1/UpdateService/FirmwareInventory"},"Id":"UpdateService","Name":"Update
+        Service"}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:56 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/UpdateService/FirmwareInventory
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:56 GMT
+      Content-Length:
+      - '332'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/UpdateService/FirmwareInventory/","Members":[{"@odata.id":"/redfish/v1/UpdateService/FirmwareInventory/Bios"},{"@odata.id":"/redfish/v1/UpdateService/FirmwareInventory/NIC-drvs"},{"@odata.id":"/redfish/v1/UpdateService/FirmwareInventory/UEFI"}],"Members@odata.count":3,"Name":"SoftwareInventoryCollection"}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:56 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/UpdateService/FirmwareInventory/Bios
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:56 GMT
+      Content-Length:
+      - '323'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/UpdateService/FirmwareInventory/Bios","Description":"The
+        information on Bios firmware.","Id":"Bios","Name":"Bios","RelatedItem":[{"@odata.id":"/redfish/v1/Systems/System-1-1-1-1"},{"@odata.id":"/redfish/v1/Systems/System-1-1-1-2"}],"RelatedItem@odata.count":2,"SoftwareId":"IVE1","Version":"1.20"}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:56 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/UpdateService/FirmwareInventory/NIC-drvs
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:56 GMT
+      Content-Length:
+      - '195'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/UpdateService/FirmwareInventory/NIC-drvs","Description":"The
+        information on NIC drivers.","Id":"NIC-drvs","Name":"NIC-drvs","SoftwareId":"NIC-45-HJK","Version":"5.32.5"}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:56 GMT
+- request:
+    method: get
+    uri: https://REDFISH_HOST:8889/redfish/v1/UpdateService/FirmwareInventory/UEFI
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.64.0
+      Accept:
+      - application/json
+      Odata-Version:
+      - '4.0'
+      X-Auth-Token:
+      - cefd9360-62e8-46a2-850f-fb81ae472c2e
+  response:
+    status:
+      code: 200
+      message: 'OK '
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - WEBrick/1.4.2 (Ruby/2.5.5/2019-03-15) OpenSSL/1.1.1c
+      Date:
+      - Mon, 08 Jul 2019 21:02:56 GMT
+      Content-Length:
+      - '270'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.id":"/redfish/v1/UpdateService/FirmwareInventory/UEFI","Description":"The
+        information on UEFI.","Id":"UEFI","Name":"UEFI","RelatedItem":[{"@odata.id":"/redfish/v1/Systems/System-1-2-1-1"}],"RelatedItem@odata.count":1,"SoftwareId":"MyGTH-76","Version":"2.50.4a"}'
+    http_version: 
+  recorded_at: Mon, 08 Jul 2019 21:02:56 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Commits in this PR expand Redfish inventory parser and add the following functionality:

 1. ability to parse server's NICs,
 2. ability to parse server's storage adapters (RAID etc.) and
 3. ability to parse firmware that is currently installed on the server.

The vast majority of code changes are in the VCR recordings that we separated into a separate commit.

This PR depends on:

  * [x] https://github.com/ManageIQ/manageiq-providers-redfish/pull/84

@miq-bot assign @agrare 