### PR TITLE
Replace local inventory-related definitions

### DIFF
--- a/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
@@ -28,7 +28,9 @@ module ManageIQ::Providers::Redfish
           :raw_power_state  => s.PowerState,
           :type             => "ManageIQ::Providers::Redfish::PhysicalInfraManager::PhysicalServer",
         )
-        persister.computer_systems.build(:managed_entity => server)
+        persister.physical_server_computer_systems.build(
+          :managed_entity => server
+        )
       end
     end
 
@@ -79,8 +81,8 @@ module ManageIQ::Providers::Redfish
     def hardwares
       collector.physical_servers.each do |s|
         server = persister.physical_servers.lazy_find(s["@odata.id"])
-        computer = persister.computer_systems.lazy_find(server)
-        persister.hardwares.build(
+        computer = persister.physical_server_computer_systems.lazy_find(server)
+        persister.physical_server_hardwares.build(
           :computer_system => computer,
           :cpu_total_cores => get_server_cpu_core_count(s),
           :disk_capacity   => get_server_disk_capacity(s),

--- a/app/models/manageiq/providers/redfish/inventory/persister/definitions/physical_infra_collections.rb
+++ b/app/models/manageiq/providers/redfish/inventory/persister/definitions/physical_infra_collections.rb
@@ -5,8 +5,9 @@ module ManageIQ::Providers::Redfish::Inventory::Persister::Definitions::Physical
     %i(
       physical_servers
       physical_server_details
-      computer_systems
-      hardwares
+      physical_server_computer_systems
+      physical_server_hardwares
+
       physical_racks
       physical_chassis
       physical_chassis_details

--- a/app/models/manageiq/providers/redfish/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager.rb
@@ -10,22 +10,6 @@ module ManageIQ::Providers::Redfish
     include ManagerMixin
     include_concern "Operations"
 
-    has_many :physical_server_details,
-             :class_name => "AssetDetail",
-             :source     => :asset_detail,
-             :through    => :physical_servers,
-             :as         => :physical_server
-    has_many :physical_chassis_details,
-             :class_name => "AssetDetail",
-             :source     => :asset_detail,
-             :through    => :physical_chassis
-    has_many :computer_systems,
-             :through => :physical_servers,
-             :as      => :computer_system
-    has_many :hardwares,
-             :through => :physical_servers,
-             :as      => :hardware
-
     def self.ems_type
       @ems_type ||= "redfish_ph_infra".freeze
     end

--- a/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/redfish/physical_infra_manager/refresher_spec.rb
@@ -182,8 +182,8 @@ describe ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher do
     expect(ems.physical_servers.count).to eq(3)
     expect(ems.physical_servers.map(&:ems_ref)).to match_array(servers.keys)
     expect(ems.physical_server_details.count).to eq(3)
-    expect(ems.computer_systems.count).to eq(3)
-    expect(ems.hardwares.count).to eq(3)
+    expect(ems.physical_server_computer_systems.count).to eq(3)
+    expect(ems.physical_server_hardwares.count).to eq(3)
 
     expect(ems.physical_racks.count).to eq(2)
     expect(ems.physical_racks.map(&:ems_ref)).to match_array(racks.keys)


### PR DESCRIPTION
Since all of the relationships and inventory definitions that we are using are included in the core repo, we can drop the local definitions and replace them with the definitions from the core repo.

This PR depends on:

  * [x] https://github.com/ManageIQ/manageiq/pull/18953

@miq-bot assign @agrare 