### PR TITLE
Remove gettext initializer

### DIFF
--- a/config/initializers/gettext.rb
+++ b/config/initializers/gettext.rb
@@ -1,5 +1,0 @@
-Vmdb::Gettext::Domains.add_domain(
-  'ManageIQ_Providers_Redfish',
-  ManageIQ::Providers::Redfish::Engine.root.join('locale').to_s,
-  :po
-)

--- a/zanata.xml
+++ b/zanata.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<config xmlns="http://zanata.org/namespace/config/">
-  <url>https://translate.zanata.org/</url>
-  <project>manageiq-providers-redfish</project>
-  <project-version>master</project-version>
-  <project-type>gettext</project-type>
-</config>


### PR DESCRIPTION
There's no need for the plugin to initialize its own gettext catalogs. Also, removing `zanata.xml`.