### PR TITLE
Remove to_json from toolbar data as it's not needed

### DIFF
--- a/app/helpers/manageiq/providers/redfish/toolbar_overrides/physical_server_center.rb
+++ b/app/helpers/manageiq/providers/redfish/toolbar_overrides/physical_server_center.rb
@@ -24,7 +24,7 @@ module ManageIQ::Providers::Redfish
                   :button         => :physical_server_provision,
                   :modal_title    => N_("Provision Physical Server"),
                   :component_name => "RedfishServerProvisionDialog",
-                }.to_json,
+                },
               }
             ),
             button(
@@ -40,7 +40,7 @@ module ManageIQ::Providers::Redfish
                   :button         => :physical_server_firmware_update,
                   :modal_title    => N_("Update Physical Server Firmware"),
                   :component_name => "RedfishServerFirmwareUpdateDialog",
-                }.to_json,
+                },
               }
             ),
           ]

--- a/app/helpers/manageiq/providers/redfish/toolbar_overrides/physical_servers_center.rb
+++ b/app/helpers/manageiq/providers/redfish/toolbar_overrides/physical_servers_center.rb
@@ -24,7 +24,7 @@ module ManageIQ::Providers::Redfish
                   :button         => :physical_server_provision,
                   :modal_title    => N_("Provision Selected Physical Servers"),
                   :component_name => "RedfishServerProvisionDialog",
-                }.to_json,
+                },
               },
               :enabled => false,
               :onwhen  => "1+"
@@ -42,7 +42,7 @@ module ManageIQ::Providers::Redfish
                   :button         => :physical_server_firmware_update,
                   :modal_title    => N_("Update Physical Servers' Firmware"),
                   :component_name => "RedfishServerFirmwareUpdateDialog",
-                }.to_json,
+                },
               },
               :enabled => false,
               :onwhen  => "1+"


### PR DESCRIPTION
After ManageIQ/manageiq-ui-classic#5997 `to_json` is not needed and will break the data format.

Related to ManageIQ/manageiq-ui-classic#6289 fix but **not** dependent either way.

Before:
Button `Provision Physical Server` and `Update Firmware of Physical Server` don't work click.
After:
Buttons work as expected.

@miq-bot add_label ivanchuk/no