### PR TITLE
Remove inventory refresh from settings

### DIFF
--- a/app/models/manageiq/providers/redfish/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager.rb
@@ -14,6 +14,10 @@ module ManageIQ::Providers::Redfish
       @ems_type ||= "redfish_ph_infra".freeze
     end
 
+    def inventory_object_refresh?
+      true
+    end
+
     def self.description
       @description ||= "Redfish".freeze
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,10 +8,6 @@
           :critical:
           - !ruby/regexp /^redfish_/
 
-:ems_refresh:
-  :redfish_ph_infra:
-    :inventory_object_refresh: true
-
 :http_proxy:
   :redfish:
     :host:


### PR DESCRIPTION
Not quite like all the other ones but close. Remove inventory_object_refresh from settings as part of the effort to remove the old legacy EmsRefresh and save_inventory refresh code.