### PR TITLE
Fix the loading of customization templates in the provisioning form

### DIFF
--- a/app/javascript/components/redfish-server-provision-dialog.jsx
+++ b/app/javascript/components/redfish-server-provision-dialog.jsx
@@ -46,7 +46,9 @@ class RedfishServerProvisionDialog extends React.Component {
       fetchPxeImagesForServer(formState.values.pxeServer).then(images => {
         this.setState({pxeImages: images.resources.map(this.pxeImageToSelectOption)});
       }, handleApiError(this));
-    } else if(formState.modified.pxeImage){
+    }
+
+    if(formState.modified.pxeImage){
       fetchTemplatesForPxeImage(formState.values.pxeImage).then(templates => {
         this.setState({customizationTemplates: templates.resources.map(this.templateToSelectOption)});
       }, handleApiError(this));


### PR DESCRIPTION
This fixes the bug described at the beginning of https://github.com/ManageIQ/manageiq-providers-redfish/issues/105

@miq-bot add_label bug
@miq-bot add_reviewer @agrare 
@miq-bot add_reviewer @matejart 