### PR TITLE
Make the PhysicalServer related buttons tied more to the provider

### DIFF
--- a/app/helpers/manageiq/providers/redfish/button/physical_server_button.rb
+++ b/app/helpers/manageiq/providers/redfish/button/physical_server_button.rb
@@ -1,0 +1,7 @@
+module ManageIQ::Providers::Redfish
+  class Button::PhysicalServerButton < ::ApplicationHelper::Button::ButtonWithoutRbacCheck
+    def visible?
+      ::ManageIQ::Providers::Redfish::PhysicalInfraManager::PhysicalServer.any?
+    end
+  end
+end

--- a/app/helpers/manageiq/providers/redfish/toolbar_overrides/physical_servers_center.rb
+++ b/app/helpers/manageiq/providers/redfish/toolbar_overrides/physical_servers_center.rb
@@ -1,6 +1,5 @@
 module ManageIQ::Providers::Redfish
-  class ToolbarOverrides::PhysicalServersCenter \
-      < ::ApplicationHelper::Toolbar::Override
+  class ToolbarOverrides::PhysicalServersCenter < ::ApplicationHelper::Toolbar::Override
     button_group(
       "physical_server_policy",
       [
@@ -14,9 +13,9 @@ module ManageIQ::Providers::Redfish
             button(
               :physical_server_provision,
               "pficon pficon-add-circle-o fa-lg",
-              t = N_("Provision Selected Physical Servers"),
+              t = N_("Provision Selected Redfish Physical Servers"),
               t,
-              :klass   => ApplicationHelper::Button::ButtonWithoutRbacCheck,
+              :klass   => Button::PhysicalServerButton,
               :data    => {
                 "function"      => "sendDataWithRx",
                 "function-data" => {
@@ -32,9 +31,9 @@ module ManageIQ::Providers::Redfish
             button(
               :physical_server_firmware_update,
               "pficon pficon-maintenance fa-lg",
-              t = N_("Update Firmware of Physical Servers"),
+              t = N_("Update Firmware of Selected Redfish Physical Servers"),
               t,
-              :klass   => ApplicationHelper::Button::ButtonWithoutRbacCheck,
+              :klass   => Button::PhysicalServerButton,
               :data    => {
                 "function"      => "sendDataWithRx",
                 "function-data" => {


### PR DESCRIPTION
These buttons show up in the generic Physical Servers summary screen where it's not guaranteed that we would have any redfish physical servers. As we have no direct way to limit the scope of these buttons from the frontend, the only viable option I could come up with was to include the name of the provider in the button text:

![Screenshot from 2020-05-21 17-44-44](https://user-images.githubusercontent.com/649130/82577160-e0f27680-9b8a-11ea-8ac7-541f22c21a9d.png)

Also when there are not Redfish physical servers in our inventory, displaying the button is pointless, so I added a check for that as well.

Fixes https://github.com/ManageIQ/manageiq-providers-redfish/issues/111
@miq-bot add_label bug