### PR TITLE
Logout after collecting inventory

### DIFF
--- a/app/models/manageiq/providers/redfish/inventory/collector.rb
+++ b/app/models/manageiq/providers/redfish/inventory/collector.rb
@@ -1,9 +1,5 @@
 module ManageIQ::Providers::Redfish
   class Inventory::Collector < ManageIQ::Providers::Inventory::Collector
     require_nested :PhysicalInfraManager
-
-    def rf_client
-      @rf_client ||= manager.connect
-    end
   end
 end

--- a/spec/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager_spec.rb
@@ -1,5 +1,6 @@
 describe ManageIQ::Providers::Redfish::Inventory::Parser::PhysicalInfraManager do
   def new_resource(content)
+    require "redfish_client"
     RedfishClient::Resource.new(nil, :raw => content)
   end
 


### PR DESCRIPTION
The Redfish provider leaks a session every refresh because we have to logout after collecting the inventory.

https://github.com/ManageIQ/manageiq-providers-redfish/issues/113