### PR TITLE
Set the monitor_running event to unblock the main thread

### DIFF
--- a/app/models/manageiq/providers/redfish/physical_infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/redfish/physical_infra_manager/event_catcher/runner.rb
@@ -2,8 +2,8 @@ module ManageIQ::Providers::Redfish
   class PhysicalInfraManager::EventCatcher::Runner \
       < ManageIQ::Providers::BaseManager::EventCatcher::Runner
     def monitor_events
+      event_monitor_running
       event_stream.listen do |event|
-        event_monitor_running
         @queue << event
       end
     end


### PR DESCRIPTION
Without setting the monitor_running concurrent event the main event_catcher worker thread doesn't ever leave the do_before_work_loop which means it can't be shutdown cleanly until the first event is raised.

Related to: https://github.com/ManageIQ/manageiq-providers-amazon/pull/633