### PR TITLE
convert regexp event detection to strings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,7 +6,7 @@
       :event_groups:
         :general:
           :critical:
-          - !ruby/regexp /^redfish_/
+          - /^redfish_/
 :http_proxy:
   :redfish:
     :host:


### PR DESCRIPTION
part of https://github.com/ManageIQ/manageiq/pull/20907

In order to better support json configuration settings, the regular
expressions in settings.yml are being converted to strings.
The event system is now responsible to handle the appropriately