### PR TITLE
Fix service_url when using ssl-no-validation

### DIFF
--- a/app/models/manageiq/providers/redfish/manager_mixin.rb
+++ b/app/models/manageiq/providers/redfish/manager_mixin.rb
@@ -153,14 +153,8 @@ module ManageIQ::Providers::Redfish::ManagerMixin
       end
     end
 
-    SCHEME_LUT = {
-      "ssl"                 => "https",
-      "ssl-with-validation" => "https",
-      "non-ssl"             => "http"
-    }.freeze
-
     def service_url(protocol, host, port)
-      scheme = SCHEME_LUT[protocol]
+      scheme = protocol == "non-ssl" ? "http" : "https"
       URI::Generic.build(:scheme => scheme, :host => host, :port => port).to_s
     end
 


### PR DESCRIPTION
When building the URL to use we were checking for non-ssl, ssl-with-validation, and ssl as the protocol.  Rather than ssl the DDF form uses ssl-no-validation which was causing the scheme to be nil and making it impossible to add the provider.

Fixes https://github.com/ManageIQ/manageiq/issues/21897