### PR TITLE
Fix initial value bug with isSearchable select

### DIFF
--- a/app/javascript/components/firmware-update.schema.js
+++ b/app/javascript/components/firmware-update.schema.js
@@ -1,6 +1,6 @@
 import { componentTypes, validatorTypes } from '@@ddf';
 
-const createSchema = (fetchPromise) => ({
+const createSchema = (firmwareBinaryOptions) => ({
   fields: [{
     component: componentTypes.SELECT,
     id: 'firmwareBinary',
@@ -13,7 +13,7 @@ const createSchema = (fetchPromise) => ({
       type: validatorTypes.REQUIRED,
       message: __('Firmware Binary is required'),
     }],
-    loadOptions: () => fetchPromise,
+    options: firmwareBinaryOptions,
   }],
 });
 


### PR DESCRIPTION
Fixed a bug described in this file: https://github.com/ManageIQ/manageiq-providers-redfish/blob/53397a19a47e3c131dc79cd432c895c7b655a8bb/app/javascript/components/server-provision.schema.js#L3

This bug occurs when you have a searchable select field while using `loadOptions`. The initial value of the field will not display in the form when using `loadOptions` and `isSearchable: true`

@miq-bot add_reviewer @agrare 
@miq-bot add_reviewer @Fryguy
@miq-bot assign @agrare 
@miq-bot add-label bug