### PR TITLE
Handle missing UpdateService

### DIFF
--- a/app/models/manageiq/providers/redfish/inventory/collector/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/inventory/collector/physical_infra_manager.rb
@@ -22,7 +22,7 @@ module ManageIQ::Providers::Redfish
     end
 
     def firmware_inventory
-      @firmware_inventory ||= connection.UpdateService.FirmwareInventory&.Members || []
+      @firmware_inventory ||= connection.UpdateService&.FirmwareInventory&.Members || []
     end
 
     private


### PR DESCRIPTION
If the UpdateService is missing (e.g. in a simulator) this was causing
the refresh to fail while listing firmwares.