### PR TITLE
[WIP] Fix refresh if the location is `nil`

### DIFF
--- a/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb
@@ -81,6 +81,8 @@ module ManageIQ::Providers::Redfish
     end
 
     def format_location(location)
+      return if location.nil?
+
       %w(HouseNumber Street City Country).collect do |field|
         location.dig("PostalAddress", field)
       end.compact.join(", ")


### PR DESCRIPTION
```
ERROR -- evm: MIQ(ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher#refresh) EMS: [10.2.2.250], id: [3] Refresh failed
ERROR -- evm: /opt/manageiq/manageiq-gemset/bundler/gems/manageiq-providers-redfish-0a009d144955/app/models/manageiq/providers/redfish/inventory/parser/physical_infra_manager.rb:85:in `dig'
ERROR -- evm: MIQ(ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher#refresh) EMS: [10.2.2.250], id: [3] Unable to perform refresh for the following targets:
ERROR -- evm: MIQ(ManageIQ::Providers::Redfish::PhysicalInfraManager::Refresher#refresh)  --- ManageIQ::Providers::Redfish::PhysicalInfraManager [] id [3]