### PR TITLE
Update node 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/ManageIQ/manageiq-providers-redfish#readme",
   "engines": {
-    "node": ">= 20.19.1",
+    "node": ">= 22.22.0",
     "npm": ">= 10.8.2",
     "yarn": ">= 0.20.1"
   },


### PR DESCRIPTION
Part of: https://github.com/ManageIQ/manageiq/issues/23810
Update Node version to Node 22.

@miq-bot assign @Fryguy
@miq-bot add-label dependencies